### PR TITLE
initial implementation

### DIFF
--- a/.dwollaci.yml
+++ b/.dwollaci.yml
@@ -1,0 +1,5 @@
+stages:
+  build:
+    nodeLabel: sbt
+    steps:
+      - sbt +test

--- a/.travis/release.sh
+++ b/.travis/release.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset
+
+USERNAME="Dwolla Bot"
+RELEASE_BRANCH="main"
+
+commit_username=$(git log -n1 --format=format:"%an")
+if [[ "$commit_username" == "$USERNAME" ]]; then
+  echo "Refusing to release a commit created by this script."
+  exit 0
+fi
+
+if [ "$TRAVIS_BRANCH" != "${RELEASE_BRANCH}" ]; then
+  echo "Only the ${RELEASE_BRANCH} branch will be released. This branch is $TRAVIS_BRANCH."
+  exit 0
+fi
+
+git config user.name "$USERNAME"
+git config user.email "dev+dwolla-bot@dwolla.com"
+
+git remote add release https://$GH_TOKEN@github.com/Dwolla/fs2-pgp.git
+git fetch release
+
+git clean -dxf
+git checkout ${RELEASE_BRANCH}
+git branch --set-upstream-to=release/${RELEASE_BRANCH}
+
+MASTER=$(git rev-parse HEAD)
+if [ "$TRAVIS_COMMIT" != "$MASTER" ]; then
+  echo "Checking out ${RELEASE_BRANCH} set HEAD to $MASTER, but Travis was building $TRAVIS_COMMIT, so refusing to continue."
+  exit 0
+fi
+
+ sbt clean "release with-defaults"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,8 @@
+The MIT License (MIT)
+Copyright © 2020 Dwolla
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/build.sbt
+++ b/build.sbt
@@ -66,7 +66,7 @@ lazy val `fs2-pgp` = (project in file("."))
         "com.chuusai" %% "shapeless" % "2.3.3",
         "org.scala-lang.modules" %% "scala-collection-compat" % "2.2.0",
         "io.chrisdavenport" %% "log4cats-core" % log4catsV,
-        "io.chrisdavenport" %% "log4cats-slf4j" % log4catsV % Test,
+        "org.scalatest" %% "scalatest" % "3.2.2" % Test,
         "com.codecommit" %% "cats-effect-testing-scalatest-scalacheck" % "0.4.1" % Test,
       )
     },

--- a/src/main/scala/com/dwolla/security/crypto/BouncyCastleResource.scala
+++ b/src/main/scala/com/dwolla/security/crypto/BouncyCastleResource.scala
@@ -1,0 +1,26 @@
+package com.dwolla.security.crypto
+
+import java.security.Security
+
+import cats.effect._
+import cats.syntax.all._
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+
+sealed trait BouncyCastleResource
+object BouncyCastleResource {
+  def apply[F[_] : Sync : ContextShift](blocker: Blocker,
+                                        removeOnClose: Boolean = true): Resource[F, BouncyCastleResource] = {
+    def registerBouncyCastle: F[String] =
+      for {
+        provider <- blocker.delay(new BouncyCastleProvider)
+        _ <- blocker.delay(Security.addProvider(provider))
+      } yield provider.getName
+
+    def removeBouncyCastle(name: String): F[Unit] =
+      if (removeOnClose)
+        blocker.delay(Security.removeProvider(name))
+      else ().pure[F]
+
+    Resource.make(registerBouncyCastle)(removeBouncyCastle).as(new BouncyCastleResource {})
+  }
+}

--- a/src/main/scala/com/dwolla/security/crypto/CryptoAlg.scala
+++ b/src/main/scala/com/dwolla/security/crypto/CryptoAlg.scala
@@ -1,0 +1,183 @@
+package com.dwolla.security.crypto
+
+import java.io._
+
+import cats.effect._
+import cats.syntax.all._
+import com.dwolla.security.crypto.Compression._
+import com.dwolla.security.crypto.Encryption._
+import com.dwolla.security.crypto.PgpLiteralDataPacketFormat._
+import io.chrisdavenport.log4cats.Logger
+import fs2._
+import fs2.io._
+import org.bouncycastle.bcpg._
+import org.bouncycastle.openpgp._
+import org.bouncycastle.openpgp.operator.bc.BcPublicKeyDataDecryptorFactory
+import org.bouncycastle.openpgp.operator.jcajce._
+
+trait CryptoAlg[F[_]] {
+  def encrypt(key: PGPPublicKey,
+              chunkSize: ChunkSize = defaultChunkSize,
+              fileName: Option[String] = None,
+              encryption: Encryption = Aes256,
+              compression: Compression = Zip,
+              packetFormat: PgpLiteralDataPacketFormat = Binary,
+             ): Pipe[F, Byte, Byte]
+
+  def decrypt(key: PGPPrivateKey,
+              chunkSize: ChunkSize = defaultChunkSize,
+             ): Pipe[F, Byte, Byte]
+
+  def armor(chunkSize: ChunkSize = defaultChunkSize): Pipe[F, Byte, Byte]
+}
+
+object CryptoAlg {
+  private def addKey[F[_] : Sync : ContextShift](blocker: Blocker)
+                                 (pgpEncryptedDataGenerator: PGPEncryptedDataGenerator, key: PGPPublicKey): F[Unit] =
+    blocker.delay(pgpEncryptedDataGenerator.addMethod(new JcePublicKeyKeyEncryptionMethodGenerator(key)))
+
+  private type PgpEncryptionPipelineComponents = (PGPEncryptedDataGenerator, PGPCompressedDataGenerator, PGPLiteralDataGenerator)
+
+  /**
+   * The order in which these armoring and generator resources are
+   * created matters, because they need to be closed in the right
+   * order for the encrypted data to be written out correctly.
+   */
+  private def pgpGenerators[F[_] : Sync : ContextShift](blocker: Blocker,
+                                                        encryption: Encryption,
+                                                        compression: Compression,
+                                                       ): Resource[F, PgpEncryptionPipelineComponents] =
+    for {
+      pgpEncryptedDataGenerator <- Resource.make(blocker.delay(new PGPEncryptedDataGenerator(new JcePGPDataEncryptorBuilder(encryption.tag).setWithIntegrityPacket(true))))(g => blocker.delay(g.close()))
+      pgpCompressedDataGenerator <- Resource.make(blocker.delay(new PGPCompressedDataGenerator(compression.tag)))(c => blocker.delay(c.close()))
+      pgpLiteralDataGenerator <- Resource.make(blocker.delay(new PGPLiteralDataGenerator()))(g => blocker.delay(g.close()))
+    } yield (pgpEncryptedDataGenerator, pgpCompressedDataGenerator, pgpLiteralDataGenerator)
+
+  /**
+   * This method takes an <code>OutputStream</code> that will essentially be the
+   * place where encrypted bytes are written, and returns an
+   * OutputStream that accepts plaintext for encryption.
+   *
+   * The data flow is as follows:
+   *
+   * Plaintext -> "Literal Data" Packetizer -> Compressor -> Encryptor -> OutputStream provided by caller
+   */
+  private def encryptingOutputStream[F[_] : Sync : ContextShift : Clock](blocker: Blocker,
+                                                                         key: PGPPublicKey,
+                                                                         chunkSize: ChunkSize,
+                                                                         fileName: Option[String],
+                                                                         encryption: Encryption,
+                                                                         compression: Compression,
+                                                                         packetFormat: PgpLiteralDataPacketFormat,
+                                                                         outputStreamIntoWhichToWriteEncryptedBytes: OutputStream): Resource[F, OutputStream] =
+    pgpGenerators[F](blocker, encryption, compression)
+      .evalTap { case (pgpEncryptedDataGenerator, _, _) =>
+        addKey[F](blocker)(pgpEncryptedDataGenerator, key)
+      }
+      .evalMap { case (pgpEncryptedDataGenerator, pgpCompressedDataGenerator, pgpLiteralDataGenerator) =>
+        for {
+          now <- Clock[F].realTime(scala.concurrent.duration.MILLISECONDS).map(new java.util.Date(_))
+          encryptor <- blocker.delay(pgpEncryptedDataGenerator.open(outputStreamIntoWhichToWriteEncryptedBytes, Array.ofDim[Byte](chunkSize)))
+          compressor <- blocker.delay(pgpCompressedDataGenerator.open(encryptor))
+          literalizer <- blocker.delay(pgpLiteralDataGenerator.open(compressor, packetFormat.tag, fileName.getOrElse(PGPLiteralData.CONSOLE), now, Array.ofDim[Byte](chunkSize)))
+        } yield literalizer
+      }
+
+  def apply[F[_] : ConcurrentEffect : ContextShift : Clock : Logger](blocker: Blocker,
+                                                                     removeOnClose: Boolean = true): Resource[F, CryptoAlg[F]] =
+    for {
+      _ <- BouncyCastleResource[F](blocker, removeOnClose)
+    } yield new CryptoAlg[F] {
+      import scala.jdk.CollectionConverters._
+
+      private implicit val SLogger: Logger[Stream[F, *]] = Logger[F].mapK(Stream.functionKInstance[F])
+      private val fingerprintCalculator = new JcaKeyFingerprintCalculator
+
+      override def encrypt(key: PGPPublicKey,
+                           chunkSize: ChunkSize,
+                           fileName: Option[String] = None,
+                           encryption: Encryption = Aes256,
+                           compression: Compression = Zip,
+                           packetFormat: PgpLiteralDataPacketFormat = Binary,
+                          ): Pipe[F, Byte, Byte] =
+        _.through { bytes =>
+          readOutputStream(blocker, chunkSize) { outputStreamToRead =>
+            Stream
+              .resource(encryptingOutputStream[F](blocker, key, chunkSize, fileName, encryption, compression, packetFormat, outputStreamToRead))
+              .flatMap(wos => bytes.through(writeOutputStream(wos.pure[F], blocker)))
+              .compile
+              .drain
+          }
+        }
+
+      private def pgpInputStreamToByteStream(key: PGPPrivateKey,
+                                             chunkSize: ChunkSize): InputStream => Stream[F, Byte] = {
+        def pgpCompressedDataToBytes(pcd: PGPCompressedData): Stream[F, Byte] =
+          Logger[Stream[F, *]].trace("Found compressed data") >>
+            pgpInputStreamToByteStream(key, chunkSize)(pcd.getDataStream)
+
+        /*
+         * Literal data is not to be further processed, so its contents
+         * are the bytes to be read and output.
+         */
+        def pgpLiteralDataToBytes(pld: PGPLiteralData): Stream[F, Byte] =
+          Logger[Stream[F, *]].trace(s"found literal data for file: ${pld.getFileName} and format: ${pld.getFormat}") >>
+            readInputStream(blocker.delay(pld.getDataStream), chunkSize, blocker)
+
+        def pgpEncryptedDataListToBytes(pedl: PGPEncryptedDataList): Stream[F, Byte] = {
+          Logger[Stream[F, *]].trace(s"found ${pedl.size()} encrypted data packets") >>
+            Stream.fromIterator[F](pedl.iterator().asScala)
+              .evalMap {
+                case pbe: PGPPublicKeyEncryptedData =>
+                  if (key.getKeyID != pbe.getKeyID) KeyMismatchException(key.getKeyID, pbe.getKeyID).raiseError[F, InputStream]
+                  else blocker.delay(pbe.getDataStream(new BcPublicKeyDataDecryptorFactory(key)))
+                case other =>
+                  Logger[F].error(EncryptionTypeError)(s"found wrong type of encrypted data: $other") >>
+                    EncryptionTypeError.raiseError[F, InputStream]
+              }
+              .flatMap(pgpInputStreamToByteStream(key, chunkSize))
+        }
+
+        def ignore(s: String): Stream[F, Byte] =
+          Logger[Stream[F, *]].trace(s"ignoring ${s}") >> Stream.empty
+
+        pgpIS =>
+          Stream.eval(Logger[F].trace("starting pgpInputStreamToByteStream")).drain ++
+          Stream.fromBlockingIterator[F](
+            blocker,
+            new PGPObjectFactory(pgpIS, fingerprintCalculator).iterator().asScala
+          )
+            .flatMap {
+              case _: PGPSignatureList => ignore("PGPSignatureList")
+              case _: PGPSecretKeyRing => ignore("PGPSecretKeyRing")
+              case _: PGPPublicKeyRing => ignore("PGPPublicKeyRing")
+              case _: PGPPublicKey => ignore("PGPPublicKey")
+              case x: PGPCompressedData => pgpCompressedDataToBytes(x)
+              case x: PGPLiteralData => pgpLiteralDataToBytes(x)
+              case x: PGPEncryptedDataList => pgpEncryptedDataListToBytes(x)
+              case _: PGPOnePassSignatureList => ignore("PGPOnePassSignatureList")
+              case _: PGPMarker => ignore("PGPMarker")
+              case other => Logger[Stream[F, *]].warn(s"found unexpected $other") >> Stream.empty
+            }
+      }
+
+      override def decrypt(key: PGPPrivateKey,
+                           chunkSize: ChunkSize): Pipe[F, Byte, Byte] =
+        _.through(toInputStream[F])
+          .evalTap(_ => Logger[F].trace("we have an InputStream containing the cryptotext"))
+          .evalMap { cryptoIS =>
+            blocker.delay {
+              PGPUtil.getDecoderStream(cryptoIS)
+            }
+          }
+          .flatMap(pgpInputStreamToByteStream(key, chunkSize))
+
+      override def armor(chunkSize: ChunkSize): Pipe[F, Byte, Byte] = bytes =>
+        readOutputStream(blocker, chunkSize) { out =>
+          (for {
+            armorer: OutputStream <- Resource.fromAutoCloseableBlocking(blocker)(blocker.delay(new ArmoredOutputStream(out)))
+            _ <- bytes.through(writeOutputStream(armorer.pure[F], blocker)).compile.resource.drain
+          } yield ()).use(_ => ().pure[F])
+        }
+    }
+}

--- a/src/main/scala/com/dwolla/security/crypto/PGPKeyAlg.scala
+++ b/src/main/scala/com/dwolla/security/crypto/PGPKeyAlg.scala
@@ -1,0 +1,96 @@
+package com.dwolla.security.crypto
+
+import java.io.ByteArrayInputStream
+import java.nio.charset.Charset
+
+import cats._
+import cats.effect._
+import fs2._
+import org.bouncycastle.openpgp._
+import org.bouncycastle.openpgp.operator.bc.{BcPBESecretKeyDecryptorBuilder, BcPGPDigestCalculatorProvider}
+import org.bouncycastle.openpgp.operator.jcajce.JcaKeyFingerprintCalculator
+
+trait PGPKeyAlg[F[_]] {
+  def readPublicKey(key: String): F[PGPPublicKey]
+  def readPrivateKey(key: String, passphrase: Array[Char] = Array.empty[Char]): F[PGPPrivateKey]
+}
+
+object PGPKeyAlg {
+  class PartiallyAppliedPGPKeyAlg[G[_]] private[PGPKeyAlg] () {
+    def apply[F[_] : MonadError[*[_], Throwable]](blocker: Blocker)
+                                                 (implicit G: Sync[G],
+                                                  CS: ContextShift[G],
+                                                  SC: Stream.Compiler[G, F]): PGPKeyAlg[F] = new PGPKeyAlg[F] {
+      import scala.jdk.CollectionConverters._
+
+      override def readPublicKey(key: String): F[PGPPublicKey] =
+        publicKeyStream(key)
+          .filter(_.isEncryptionKey)
+          .head
+          .compile
+          .lastOrError
+
+      override def readPrivateKey(key: String,
+                                  passphrase: Array[Char]): F[PGPPrivateKey] =
+        secretKeyStream(key)
+          .evalMap { secretKey =>
+            blocker.delay {
+              val digestCalculatorProvider = new BcPGPDigestCalculatorProvider()
+              val decryptor = new BcPBESecretKeyDecryptorBuilder(digestCalculatorProvider).build(passphrase)
+              secretKey.extractPrivateKey(decryptor)
+            }
+          }
+          .map(Option(_))
+          .unNone
+          .head
+          .compile
+          .lastOrError
+
+      private def keyBytes(armored: String): G[ByteArrayInputStream] =
+        blocker.delay {
+          new ByteArrayInputStream(armored.getBytes(Charset.forName("UTF-8")))
+        }
+
+      private def publicKeyStream(key: String): Stream[G, PGPPublicKey] =
+        for {
+          is <- Stream.eval(keyBytes(key))
+          keyRingCollection <- Stream.eval(blocker.delay {
+            new PGPPublicKeyRingCollection(PGPUtil.getDecoderStream(is), new JcaKeyFingerprintCalculator())
+          })
+          keyRing <- Stream.fromBlockingIterator(blocker, keyRingCollection.getKeyRings.asScala)
+          key <- Stream.fromBlockingIterator(blocker, keyRing.getPublicKeys.asScala)
+        } yield key
+
+      private def secretKeyStream(key: String): Stream[G, PGPSecretKey] =
+        for {
+          is <- Stream.eval(keyBytes(key))
+          keyRingCollection <- Stream.eval(blocker.delay {
+            new PGPSecretKeyRingCollection(PGPUtil.getDecoderStream(is), new JcaKeyFingerprintCalculator())
+          })
+          keyRing <- Stream.fromBlockingIterator(blocker, keyRingCollection.getKeyRings.asScala)
+          secretKey <- Stream.fromBlockingIterator(blocker, keyRing.getSecretKeys.asScala)
+        } yield secretKey
+    }
+  }
+
+  /**
+   * Starts to build a PGPKeyAlg by fixing the first higher-kinded type param
+   * that needs to be provided or inferred. The type provided here will be the
+   * main effect in which the PGPKeyAlg will operate. The second type provided
+   * to `PartiallyAppliedPGPKeyAlg.apply` will be the output type. It will
+   * typically be the same type provided here, but other types are possible:
+   *
+   * {{{
+   * val key: String = "armored key"
+   *
+   * // second HKT inferred to be IO
+   * val ioAlg: PGPKeyAlg[IO] = PGPKeyAlg[IO](blocker)
+   * val readInIO: IO[PGPPublicKey] = ioAlg.readPublicKey(key)
+   *
+   * // second HKT inferred to be Resource[IO, *]
+   * val resourceAlg: PGPKeyAlg[Resource[IO, *]] = PGPKeyAlg[IO](blocker)
+   * val readInResource: Resource[IO, PGPPublicKey] = resourceAlg.readPublicKey(key)
+   * }}}
+   */
+  def apply[F[_]]: PartiallyAppliedPGPKeyAlg[F] = new PartiallyAppliedPGPKeyAlg[F]
+}

--- a/src/main/scala/com/dwolla/security/crypto/exceptions.scala
+++ b/src/main/scala/com/dwolla/security/crypto/exceptions.scala
@@ -1,0 +1,5 @@
+package com.dwolla.security.crypto
+
+case class KeyMismatchException(expectedKeyId: Long, actualKeyId: Long) extends RuntimeException(s"Cannot decrypt message with key $actualKeyId because it requires key $expectedKeyId", null, true, false)
+
+case object EncryptionTypeError extends RuntimeException("encrypted data was not PGPPublicKeyEncryptedData", null, true, false)

--- a/src/main/scala/com/dwolla/security/crypto/package.scala
+++ b/src/main/scala/com/dwolla/security/crypto/package.scala
@@ -1,0 +1,55 @@
+package com.dwolla.security
+
+import shapeless.tag
+import shapeless.tag.@@
+import org.bouncycastle.openpgp.PGPLiteralData
+
+package object crypto {
+  type ChunkSize = Int @@ ChunkSizeTag
+  val defaultChunkSize: ChunkSize = tag[ChunkSizeTag][Int](4096)
+}
+
+package crypto {
+  trait ChunkSizeTag
+
+  sealed trait Encryption {
+    val tag: Int
+  }
+
+  object Encryption {
+    //    case object Idea extends Encryption { override val tag: Int = 1 }
+    //    case object TripleDes extends Encryption { override val tag: Int = 2 }
+    //    case object Cast5 extends Encryption { override val tag: Int = 3 }
+    //    case object Blowfish extends Encryption { override val tag: Int = 4 }
+    //    case object Safer extends Encryption { override val tag: Int = 5 }
+    //    case object Des extends Encryption { override val tag: Int = 6 }
+    //    case object Aes128 extends Encryption { override val tag: Int = 7 }
+    //    case object Aes192 extends Encryption { override val tag: Int = 8 }
+    case object Aes256 extends Encryption { override val tag: Int = 9 }
+    //    case object TwoFish extends Encryption { override val tag: Int = 10 }
+    //    case object Camellia128 extends Encryption { override val tag: Int = 11 }
+    //    case object Camellia192 extends Encryption { override val tag: Int = 12 }
+    //    case object Camellia256 extends Encryption { override val tag: Int = 13 }
+  }
+
+  sealed trait Compression {
+    val tag: Int
+  }
+
+  object Compression {
+    case object Uncompressed extends Compression { override val tag: Int = 0 }
+    case object Zip extends Compression { override val tag: Int = 1 }
+    case object Zlib extends Compression { override val tag: Int = 2 }
+    case object Bzip2 extends Compression { override val tag: Int = 3 }
+  }
+
+  sealed trait PgpLiteralDataPacketFormat {
+    val tag: Char
+  }
+
+  object PgpLiteralDataPacketFormat {
+    case object Binary extends PgpLiteralDataPacketFormat { override val tag: Char = PGPLiteralData.BINARY }
+    case object Text extends PgpLiteralDataPacketFormat { override val tag: Char = PGPLiteralData.TEXT }
+    case object Utf8 extends PgpLiteralDataPacketFormat { override val tag: Char = PGPLiteralData.UTF8 }
+  }
+}

--- a/src/test/scala/com/dwolla/security/crypto/CryptoAlgSpec.scala
+++ b/src/test/scala/com/dwolla/security/crypto/CryptoAlgSpec.scala
@@ -1,0 +1,110 @@
+package com.dwolla.security.crypto
+
+import java.io.ByteArrayOutputStream
+import java.security.KeyPairGenerator
+import java.util.Date
+
+import cats.effect._
+import cats.effect.testing.scalatest.AsyncIOSpec
+import cats.syntax.all._
+import com.dwolla.testutils._
+import io.chrisdavenport.log4cats.Logger
+import fs2._
+import org.bouncycastle.bcpg._
+import org.bouncycastle.openpgp._
+import org.bouncycastle.openpgp.operator.jcajce.JcaPGPKeyPair
+import org.scalacheck.Arbitrary._
+import org.scalacheck._
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck._
+import shapeless.tag
+
+import scala.concurrent.duration.MILLISECONDS
+
+class CryptoAlgSpec extends AsyncFlatSpec with AsyncIOSpec with Matchers with ScalaCheckPropertyChecks {
+  private implicit val noOpLogger: Logger[IO] = NoOpLogger[IO]()
+
+  behavior of "CryptoAlg"
+
+  private implicit def arbKeyPair[F[_] : Sync : ContextShift : Clock]: Arbitrary[Resource[F, PGPKeyPair]] =
+    Arbitrary {
+      Blocker[F]
+        .flatMap(BouncyCastleResource[F](_, removeOnClose = false))
+        .evalMap { _ =>
+          for {
+            pair <- Sync[F].delay {
+              val generator = KeyPairGenerator.getInstance("RSA", "BC")
+              generator.initialize(4096)
+              generator.generateKeyPair()
+            }
+            now <- Clock[F].realTime(MILLISECONDS).map(new Date(_))
+            pgpPair <- Sync[F].delay {
+              new JcaPGPKeyPair(PublicKeyAlgorithmTags.RSA_GENERAL, pair, now)
+            }
+          } yield pgpPair
+        }
+    }
+
+  private implicit def arbBytes: Arbitrary[Stream[Pure, Byte]] = Arbitrary {
+    for {
+      bytes <- arbitrary[Seq[Byte]]
+    } yield Stream.emits(bytes)
+  }
+
+  private def arbPgpBytes[F[_] : Sync : ContextShift : Clock]: Arbitrary[Resource[F, Array[Byte]]] = Arbitrary {
+    for {
+      keyPair <- arbKeyPair[F].arbitrary
+      bytes <- Gen.oneOf[Resource[F, Array[Byte]]](keyPair.map(_.getPublicKey.getEncoded), keyPair.map(_.getPrivateKey.getPrivateKeyDataPacket.getEncoded))
+    } yield bytes
+  }
+
+  private implicit val arbChunkSize: Arbitrary[ChunkSize] = Arbitrary {
+    Gen.chooseNum(1, 4096).map(tag[ChunkSizeTag][Int])
+  }
+
+  it should "round trip the plaintext" in {
+    forAll { (keyPairR: Resource[IO, PGPKeyPair],
+              bytes: Stream[Pure, Byte],
+              encryptionChunkSize: ChunkSize,
+              decryptionChunkSize: ChunkSize) =>
+      for {
+        blocker <- Blocker[IO]
+        crypto <- CryptoAlg[IO](blocker, removeOnClose = false)
+        keyPair <- keyPairR
+        roundTrip <- bytes
+          .through(crypto.encrypt(keyPair.getPublicKey, encryptionChunkSize))
+          .through(crypto.decrypt(keyPair.getPrivateKey, decryptionChunkSize))
+          .compile
+          .resource
+          .toList
+      } yield {
+        roundTrip should be(bytes.toList)
+      }
+    }
+  }
+
+  it should "support armoring a PGP value" in {
+    forAll(arbPgpBytes[IO].arbitrary) { (bytesR: Resource[IO, Array[Byte]]) =>
+      for {
+        blocker <- Blocker[IO]
+        crypto <- CryptoAlg[IO](blocker, removeOnClose = false)
+        bytes <- bytesR
+        armored <- Stream.emits(bytes).through(crypto.armor()).through(text.utf8Decode).compile.resource.string
+        expected <- Resource.liftF {
+          for {
+            out <- IO(new ByteArrayOutputStream())
+            _ <- Resource.fromAutoCloseableBlocking(blocker)(IO(new ArmoredOutputStream(out))).evalMap(arm => IO(arm.write(bytes))).use(_ => IO.unit)
+            s <- IO(new String(out.toByteArray))
+          } yield s
+        }
+      } yield {
+        armored should be(expected)
+      }
+    }
+  }
+
+  private implicit def ioCheckingAsserting[A]: CheckerAsserting[Resource[IO, A]] { type Result = IO[Unit] } =
+    new ResourceCheckerAsserting[IO, A]
+
+}

--- a/src/test/scala/com/dwolla/security/crypto/PGPKeyAlgSpec.scala
+++ b/src/test/scala/com/dwolla/security/crypto/PGPKeyAlgSpec.scala
@@ -1,0 +1,139 @@
+package com.dwolla.security.crypto
+
+import cats.effect._
+import cats.effect.testing.scalatest._
+import cats.syntax.all._
+import com.dwolla.testutils._
+import io.chrisdavenport.log4cats.Logger
+import fs2._
+import org.bouncycastle.bcpg.{HashAlgorithmTags, PublicKeyAlgorithmTags, SymmetricKeyAlgorithmTags}
+import org.bouncycastle.openpgp._
+import org.bouncycastle.openpgp.operator.PGPDigestCalculator
+import org.bouncycastle.openpgp.operator.jcajce.{JcaPGPContentSignerBuilder, JcaPGPDigestCalculatorProviderBuilder, JcePBESecretKeyEncryptorBuilder}
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalatest.flatspec._
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.{CheckerAsserting, ScalaCheckPropertyChecks}
+
+class PGPKeyAlgSpec
+  extends FixtureAsyncFlatSpec
+    with AsyncIOSpec
+    with AsyncCatsResourceIO[Blocker]
+    with Matchers
+    with DateMatchers
+    with ScalaCheckPropertyChecks
+    with PgpArbitraries {
+  private implicit val L: Logger[IO] = NoOpLogger[IO]()
+
+  override def resource: Resource[IO, Blocker] = Blocker[IO]
+
+  behavior of "PGPKeyAlg"
+
+  it should "load a PGPPublicKey from armored public key" in { blocker =>
+    val key =
+      """-----BEGIN PGP PUBLIC KEY BLOCK-----
+        |Version: GnuPG v1
+        |
+        |mQENBFVoyeYBCACy0S/9y/c/CpoYLL6aD3TMCV1Pe/0jcWN0ykULf9l4znYODZLr
+        |f10BGAJETj9ghrJCNXMib2ogz0wo43KVAp9o3mkg01vVyqs1rzM5jw+yCZmyGPFf
+        |GsE2lxZFMX+rS0dyq2w0FQN2IjYsELwIFeQ02GXTLyTlhY+u5wwCXo4e7AEXaEo7
+        |jl8129NA46gf6l+6lUMyFpKnunO7L4W5rCCrIizP4Fmll1adYfClSX6cztIfz4vg
+        |Fs2HuViPin5y8THodkg9cIkCfyNHivEbfBbx0xfx67BCwxFcYgF/84H8TASRhjRl
+        |4s1fZDA7rETWDJIcC+neNV/qtF0kY1ECSd3nABEBAAG0IFRlc3QgVXNlciA8ZnJl
+        |ZCt0ZXN0QGR3b2xsYS5jb20+iQE4BBMBAgAiBQJVaMnmAhsDBgsJCAcDAgYVCAIJ
+        |CgsEFgIDAQIeAQIXgAAKCRA2OYfNakCqV1bYB/9QNR5DN5J27Z4DIGoOto/PuVvs
+        |bQHZj8NLcvIZL1cUyKOg+oRICq2z4BXHAMqyouhs/GLiR5P74I9cJTSIudAvBhwi
+        |du9AcMQy+Qg3K1rUQGlNU+iamD8DFNUhLoK+Oicij0Mw4TSWBsoR3+Pg/jZ5SDUc
+        |dUsGGaBJthYoiJR8vZ6Uf9oCn+mpVhrso0zemBDud4AHKaVa+8o7VUWGa6jeyRHX
+        |RKVbHn7GGYiHZkl+qfpthcxyPHOIkZo+t8GVTItLpvVuU+X36N70+rIzXj5t8NDZ
+        |KfD3M4p6BSq6Cu6DtJOZ1F28hwaWiRoCdbPrJfW33fo1RxLB6+nLf/ttYGmhuQEN
+        |BFVoyeYBCADiZfKA98YQip/kvj5rBS2ilQDycBX7Ls2IftuwzO6Q9QSF2lDiz708
+        |zyvg0czQPZYaZkFgziZEmjbvOc7hDG+icVWRLCjCcZk4i2TXy7bGcTZmBQ31iVMJ
+        |ia7GxsJhu4ngrP15pZakAYcCwEk3QH17TdhOwvV8ixHmv9USCMJyiNnuhVAP2tY/
+        |Ef0EoCV6qAMoP3dNPT30sFI8+55Ce9yAtWQItT5q4vYOmC9Q34XtSxvpLsLzVByd
+        |rdvgXe0acjvMiTGcYBdjitawFYeLuz2s5mQAi4X1vcJqxBSBjG7X+1PiDqFFIid3
+        |+6rIQtR3ho+Xqz/ucGglKxtn6m49wMHJABEBAAGJAR8EGAECAAkFAlVoyeYCGwwA
+        |CgkQNjmHzWpAqldxFgf/SZIT1AiBAOLkqdWEObg0cU7n1YOXbj56sUeUCFxdbnl9
+        |V2paf2SaMB6EEGLTk9PN0GG3hPyDkl4O6w3mn2J46uP8ecVaNvTSxoq2OmkMmD1H
+        |/OSnF8a/jB6R1ODiAwekVuUMtAS7JiaAAcKcenG1f0XRKwQs52uavGXPgUuJbVtK
+        |bB0SyLBhvGG8YIWTXRMHoJRt/Ls4JEuYaoBYqfV2eDn4WhW1LVuXP13gXixy0RiV
+        |8rHs9aH8BAU7Dy0BBnaS3R9m8vtfdFxMI3/+1iGt0+xh/B4w++9oFE2DgyoZXUF8
+        |mbjKYhiRPKNoj6Rn/mHUGcnuPlKvKP+1X5bObpDbQQ==
+        |=TJUS
+        |-----END PGP PUBLIC KEY BLOCK-----""".stripMargin
+
+    for {
+      publicKey <- PGPKeyAlg[IO](blocker).readPublicKey(key)
+    } yield {
+      /**
+       * piping the public key to gpg yields the following:
+       *
+       * $ pbpaste  | gpg --show-keys --keyid-format long
+       * pub   rsa2048/363987CD6A40AA57 2015-05-29 [SC]
+       * ^^^^^^^^^^^^^^^^
+       */
+      publicKey.getKeyID should be(0x363987CD6A40AA57L)
+      publicKey.getAlgorithm should be(PublicKeyAlgorithmTags.RSA_GENERAL)
+      publicKey.getBitStrength should be(2048)
+      publicKey.getCreationTime should beTheSameInstantAs("2015-05-29T20:19:50Z")
+    }
+  }
+
+  it should "load an arbitrary armored PGP public key" in { blocker =>
+    forAll { (keyR: Resource[IO, PGPPublicKey]) =>
+      keyR.evalMap { key =>
+        val armored: IO[String] =
+          (for {
+            crypto <- Stream.resource(CryptoAlg[IO](blocker, removeOnClose = false))
+            armored <- Stream.emits(key.getEncoded)
+              .through(crypto.armor())
+              .through(text.utf8Decode)
+          } yield armored).compile.resource.string.use(s => s.pure[IO])
+
+        for {
+          armoredKey <- armored
+          output <- PGPKeyAlg[IO](blocker).readPublicKey(armoredKey)
+        } yield {
+          output.getKeyID should be(key.getKeyID)
+          output.getAlgorithm should be(key.getAlgorithm)
+          output.getBitStrength should be(key.getBitStrength)
+          output.getCreationTime should be(key.getCreationTime)
+        }
+      }
+    }
+  }
+
+  it should "load an arbitrary armored PGP private key" in { blocker =>
+    forAll(arbKeyPair[IO].arbitrary, arbitrary[Array[Char]]) { (kp, passphrase) =>
+      kp.evalMap { keyPair =>
+        val armoredKey =
+          (for {
+            crypto <- CryptoAlg[IO](blocker, removeOnClose = false)
+            secretKey <- Resource.liftF(blocker.delay {
+              val sha1Calc: PGPDigestCalculator = new JcaPGPDigestCalculatorProviderBuilder().build().get(HashAlgorithmTags.SHA1)
+              new PGPSecretKey(PGPSignature.DEFAULT_CERTIFICATION, keyPair, "identity", sha1Calc, null, null, new JcaPGPContentSignerBuilder(keyPair.getPublicKey.getAlgorithm, HashAlgorithmTags.SHA256), new JcePBESecretKeyEncryptorBuilder(SymmetricKeyAlgorithmTags.AES_256, sha1Calc).setProvider("BC").build(passphrase))
+            })
+            armoredKey <-
+              io.readOutputStream(blocker, defaultChunkSize) { os =>
+                blocker.delay(secretKey.encode(os))
+              }
+                .through(crypto.armor())
+                .through(text.utf8Decode)
+                .compile
+                .resource
+                .string
+          } yield armoredKey).use(s => s.pure[IO])
+
+        for {
+          ak <- armoredKey
+          output <- PGPKeyAlg[IO](blocker).readPrivateKey(ak, passphrase)
+        } yield {
+          output.getKeyID should be(keyPair.getPrivateKey.getKeyID)
+        }
+      }
+    }
+  }
+
+  private implicit def ioCheckingAsserting[A]: CheckerAsserting[Resource[IO, A]] { type Result = IO[Unit] } =
+    new ResourceCheckerAsserting[IO, A]
+}

--- a/src/test/scala/com/dwolla/testutils/AsyncCatsResource.scala
+++ b/src/test/scala/com/dwolla/testutils/AsyncCatsResource.scala
@@ -1,0 +1,48 @@
+package com.dwolla.testutils
+
+import cats.effect._
+import cats.effect.syntax.all._
+import org.scalatest._
+
+import scala.concurrent.duration._
+
+trait AsyncCatsResource[F[_], A] extends BeforeAndAfterAll { self: FixtureAsyncTestSuite =>
+  def resource: Resource[F, A]
+
+  implicit def ResourceEffect: Effect[F]
+  protected val ResourceTimeout: Duration = 10.seconds
+
+  private var value: Option[A] = None
+  private var shutdown: F[Unit] = ResourceEffect.unit
+
+  override def beforeAll(): Unit = {
+    ResourceEffect
+      .map(resource.allocated) {
+        case (a, shutdownAction) =>
+          value = Some(a)
+          shutdown = shutdownAction
+      }
+      .toIO
+      .unsafeRunTimed(ResourceTimeout)
+
+    ()
+  }
+
+  override def afterAll(): Unit = {
+    shutdown.toIO.unsafeRunTimed(ResourceTimeout)
+    value = None
+    shutdown = ResourceEffect.unit
+  }
+
+  override type FixtureParam = A
+
+  override def withFixture(test: OneArgAsyncTest): FutureOutcome =
+    withFixture(test.toNoArgAsyncTest(value.getOrElse {
+      fail("Resource Not Initialized When Trying to Use")
+    }))
+
+}
+
+trait AsyncCatsResourceIO[A] extends AsyncCatsResource[IO, A] { self: FixtureAsyncTestSuite =>
+  override implicit def ResourceEffect: Effect[IO] = IO.ioEffect
+}

--- a/src/test/scala/com/dwolla/testutils/DateMatchers.scala
+++ b/src/test/scala/com/dwolla/testutils/DateMatchers.scala
@@ -1,0 +1,25 @@
+package com.dwolla.testutils
+
+import java.time._
+import java.util.Date
+
+import org.scalatest.matchers.{MatchResult, Matcher}
+
+import scala.util.Try
+
+trait DateMatchers {
+  private def failed(msg: String): MatchResult =
+    MatchResult(matches = false, msg, "this shouldn't be reached")
+
+  def beTheSameInstantAs(expectedString: String): Matcher[Date] = (maybeDate: Date) =>
+    Try(Instant.parse(expectedString))
+      .fold[MatchResult](
+        _ => failed(s"Could not parse $expectedString as an Instant"),
+        beTheSameInstantAs(_)(maybeDate)
+      )
+
+  def beTheSameInstantAs(expected: Instant): Matcher[Date] = (maybeDate: Date) =>
+    Option(maybeDate).fold(failed(s"Got null, but expected $expected")) { actual =>
+      MatchResult(expected.equals(actual.toInstant), s"$actual was not $expected", s"$actual is the same instant as $expected")
+    }
+}

--- a/src/test/scala/com/dwolla/testutils/NoOpLogger.scala
+++ b/src/test/scala/com/dwolla/testutils/NoOpLogger.scala
@@ -1,0 +1,29 @@
+package com.dwolla.testutils
+
+import java.time.Instant
+
+import cats.effect._
+import cats.syntax.all._
+import io.chrisdavenport.log4cats._
+
+import scala.concurrent.duration._
+
+object NoOpLogger {
+  private def printMsg[F[_] : Sync : Clock](message: => String): F[Unit] =
+    Clock[F].realTime(MILLISECONDS).map(Instant.ofEpochMilli).flatMap { now =>
+      Sync[F].delay(println(s"$now $message"))
+    }
+
+  def apply[F[_] : Sync : Clock](print: Boolean = false): Logger[F] = new Logger[F] {
+    override def error(t: Throwable)(message: => String): F[Unit] = if(print) printMsg[F](message) else ().pure[F]
+    override def warn(t: Throwable)(message: => String): F[Unit] = if(print) printMsg[F](message) else ().pure[F]
+    override def info(t: Throwable)(message: => String): F[Unit] = if(print) printMsg[F](message) else ().pure[F]
+    override def debug(t: Throwable)(message: => String): F[Unit] = if(print) printMsg[F](message) else ().pure[F]
+    override def trace(t: Throwable)(message: => String): F[Unit] = if(print) printMsg[F](message) else ().pure[F]
+    override def error(message: => String): F[Unit] = if(print) printMsg[F](message) else ().pure[F]
+    override def warn(message: => String): F[Unit] = if(print) printMsg[F](message) else ().pure[F]
+    override def info(message: => String): F[Unit] = if(print) printMsg[F](message) else ().pure[F]
+    override def debug(message: => String): F[Unit] = if(print) printMsg[F](message) else ().pure[F]
+    override def trace(message: => String): F[Unit] = if(print) printMsg[F](message) else ().pure[F]
+  }
+}

--- a/src/test/scala/com/dwolla/testutils/PgpArbitraries.scala
+++ b/src/test/scala/com/dwolla/testutils/PgpArbitraries.scala
@@ -1,0 +1,46 @@
+package com.dwolla.testutils
+
+import java.security.KeyPairGenerator
+import java.util.Date
+
+import cats.effect._
+import cats.syntax.all._
+import com.dwolla.security.crypto.BouncyCastleResource
+import org.bouncycastle.bcpg.PublicKeyAlgorithmTags
+import org.bouncycastle.openpgp._
+import org.bouncycastle.openpgp.operator.jcajce.JcaPGPKeyPair
+import org.scalacheck._
+
+import scala.concurrent.duration.MILLISECONDS
+
+trait PgpArbitraries {
+  implicit def arbKeyPair[F[_] : Sync : ContextShift : Clock]: Arbitrary[Resource[F, PGPKeyPair]] = Arbitrary {
+    Gen.oneOf(2048, 4096).flatMap { keySize =>
+      Blocker[F]
+        .flatMap(BouncyCastleResource[F](_, removeOnClose = false))
+        .evalMap { _ =>
+          for {
+            pair <- Sync[F].delay {
+              val generator = KeyPairGenerator.getInstance("RSA", "BC")
+              generator.initialize(keySize)
+              generator.generateKeyPair()
+            }
+            now <- Clock[F].realTime(MILLISECONDS).map(new Date(_))
+            pgpPair <- Sync[F].delay {
+              new JcaPGPKeyPair(PublicKeyAlgorithmTags.RSA_GENERAL, pair, now)
+            }
+          } yield pgpPair
+        }
+    }
+  }
+
+  implicit def arbPgpPublicKey[F[_] : Sync : ContextShift : Clock]: Arbitrary[Resource[F, PGPPublicKey]] = Arbitrary {
+    arbKeyPair[F].arbitrary.map(_.map(_.getPublicKey))
+  }
+
+  implicit def arbPgpPrivateKey[F[_] : Sync : ContextShift : Clock]: Arbitrary[Resource[F, PGPPrivateKey]] = Arbitrary {
+    arbKeyPair[F].arbitrary.map(_.map(_.getPrivateKey))
+  }
+}
+
+object PgpArbitraries extends PgpArbitraries

--- a/src/test/scala/com/dwolla/testutils/ResourceCheckerAsserting.scala
+++ b/src/test/scala/com/dwolla/testutils/ResourceCheckerAsserting.scala
@@ -1,0 +1,40 @@
+package com.dwolla.testutils
+
+import cats.effect._
+import cats.effect.testing.scalatest.scalacheck.EffectCheckerAsserting
+import cats.syntax.all._
+import cats.effect.syntax.all._
+import org.scalactic.source
+import org.scalatest.exceptions._
+import org.scalatestplus.scalacheck._
+
+import scala.concurrent.duration._
+
+class ResourceCheckerAsserting[F[_] : ConcurrentEffect : Timer, A](timeout: FiniteDuration = 1.minute) extends CheckerAsserting.CheckerAssertingImpl[Resource[F, A]] {
+  private val effectCheckerAsserting = new EffectCheckerAsserting[F, A]
+  override type Result = F[Unit]
+
+  override def succeed(result: Resource[F, A]): (Boolean, Option[Throwable]) =
+    effectCheckerAsserting.succeed(result.use(x => x.pure[F]).timeout(timeout))
+
+  override def indicateSuccess(message: => String): Result = ().pure[F]
+
+  override def indicateFailure(messageFun: StackDepthException => String,
+                               undecoratedMessage: => String,
+                               scalaCheckArgs: List[Any],
+                               scalaCheckLabels: List[String],
+                               optionalCause: Option[Throwable],
+                               pos: source.Position
+                              ): Result =
+    new GeneratorDrivenPropertyCheckFailedException(
+      messageFun,
+      optionalCause,
+      pos,
+      None,
+      undecoratedMessage,
+      scalaCheckArgs,
+      None,
+      scalaCheckLabels
+    ).raiseError[F, Unit]
+
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.1-SNAPSHOT"
+version in ThisBuild := "0.1.0-SNAPSHOT"


### PR DESCRIPTION
I still need to add the encrypted credentials so TravisCI can publish this, but I wanted folks to start looking at the crypto stuff here and help vet it out.

This is a wrapper around the Java BouncyCastle PGP API, allowing users to encrypt and decrypt streams of bytes using the fs2 streaming library and cats-effect to wrap the side effects. 

Currently it only allows AES256 encryption, but we could allow the other types that BouncyCastle supports if we choose to later.