### PR TITLE
Better inference

### DIFF
--- a/src/main/scala/com/dwolla/security/crypto/BouncyCastleResource.scala
+++ b/src/main/scala/com/dwolla/security/crypto/BouncyCastleResource.scala
@@ -10,17 +10,28 @@ sealed trait BouncyCastleResource
 object BouncyCastleResource {
   def apply[F[_] : Sync : ContextShift](blocker: Blocker,
                                         removeOnClose: Boolean = true): Resource[F, BouncyCastleResource] = {
-    def registerBouncyCastle: F[String] =
+    def registerBouncyCastle: F[BouncyCastleRegistrationToken] =
       for {
         provider <- blocker.delay(new BouncyCastleProvider)
-        _ <- blocker.delay(Security.addProvider(provider))
-      } yield provider.getName
+        pos <- blocker.delay(Security.addProvider(provider))
+      } yield BouncyCastleRegistrationToken(pos, provider.getName)
 
-    def removeBouncyCastle(name: String): F[Unit] =
-      if (removeOnClose)
-        blocker.delay(Security.removeProvider(name))
-      else ().pure[F]
+    def removeBouncyCastle(token: BouncyCastleRegistrationToken): F[Unit] =
+      token match {
+        case Registered(name) if removeOnClose => blocker.delay(Security.removeProvider(name))
+        case _ => ().pure[F]
+      }
 
     Resource.make(registerBouncyCastle)(removeBouncyCastle).as(new BouncyCastleResource {})
   }
 }
+
+private[crypto] sealed trait BouncyCastleRegistrationToken
+private[crypto] object BouncyCastleRegistrationToken {
+  def apply(position: Int, name: String): BouncyCastleRegistrationToken =
+    if (-1 == position) AlreadyRegistered
+    else Registered(name)
+}
+
+private[crypto] case class Registered(name: String) extends BouncyCastleRegistrationToken
+private[crypto] case object AlreadyRegistered extends BouncyCastleRegistrationToken

--- a/src/test/scala/com/dwolla/security/crypto/PGPKeyAlgSpec.scala
+++ b/src/test/scala/com/dwolla/security/crypto/PGPKeyAlgSpec.scala
@@ -134,6 +134,21 @@ class PGPKeyAlgSpec
     }
   }
 
+  it should "infer the second Stream compiler type cleanly for IO" in { blocker =>
+    val pgpKeyAlg = PGPKeyAlg[IO](blocker)
+
+    val output = pgpKeyAlg.readPublicKey("")
+    output shouldBe an [IO[_]]
+  }
+
+  it should "infer the second Stream compiler type cleanly for Resource" in { blocker =>
+    val pgpKeyAlg = PGPKeyAlg[Resource[IO, *]](blocker)
+
+    val output = pgpKeyAlg.readPublicKey("")
+    output shouldBe a [Resource[*[_], _]]
+    output.use(_ => IO.unit) shouldBe an [IO[_]]
+  }
+
   private implicit def ioCheckingAsserting[A]: CheckerAsserting[Resource[IO, A]] { type Result = IO[Unit] } =
     new ResourceCheckerAsserting[IO, A]
 }


### PR DESCRIPTION
fixes #3 

Also tracks whether the BouncyCastle provider was actually registered during the BouncyCastleResource acquisition, and if not, doesn't remove it when the resource is torn down.