### PR TITLE
implement a queue-based OutputStream

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,8 @@ jobs:
       - name: Check that workflows are up to date
         run: sbt ++${{ matrix.scala }} githubWorkflowCheck
 
-      - name: Build project
-        run: sbt ++${{ matrix.scala }} test
+      - name: Build and test project
+        run: sbt ++${{ matrix.scala }} undeclaredCompileDependenciesTest unusedCompileDependenciesTest test
 
       - name: Compress target directories
         run: tar cf targets.tar target core/target tests/target testkit/target project/target
@@ -116,8 +116,6 @@ jobs:
         run: |
           tar xf targets.tar
           rm targets.tar
-
-      - uses: olafurpg/setup-gpg@v3
 
       - env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}

--- a/build.sbt
+++ b/build.sbt
@@ -7,6 +7,8 @@ lazy val V = new {
   val bouncyCastle = "1.66"
   val scalaTest = "3.2.3"
   val catsEffectTestingScalatestScalacheck = "0.5.0"
+  val refined = "0.9.20"
+  val shapeless = "2.3.3"
 }
 
 inThisBuild(List(
@@ -26,8 +28,8 @@ inThisBuild(List(
   githubWorkflowTargetTags ++= Seq("v*"),
   githubWorkflowPublishTargetBranches :=
     Seq(RefPredicate.StartsWith(Ref.Tag("v"))),
+  githubWorkflowBuild := Seq(WorkflowStep.Sbt(List("undeclaredCompileDependenciesTest", "unusedCompileDependenciesTest", "test"), name = Some("Build and test project"))),
   githubWorkflowPublish := Seq(WorkflowStep.Sbt(List("ci-release"))),
-  githubWorkflowPublishPreamble += WorkflowStep.Use("olafurpg", "setup-gpg", "v3"),
   githubWorkflowPublish := Seq(
     WorkflowStep.Sbt(
       List("ci-release"),
@@ -77,7 +79,7 @@ lazy val `fs2-pgp`: Project = (project in file("core"))
         "org.bouncycastle" % "bcprov-jdk15on" % V.bouncyCastle,
         "co.fs2" %% "fs2-core" % fs2V,
         "co.fs2" %% "fs2-io" % fs2V,
-        "com.chuusai" %% "shapeless" % "2.3.3",
+        "com.chuusai" %% "shapeless" % V.shapeless,
         "org.scala-lang.modules" %% "scala-collection-compat" % "2.2.0",
         "io.chrisdavenport" %% "log4cats-core" % log4catsV,
       )
@@ -107,7 +109,7 @@ lazy val `pgp-testkit`: Project = (project in file("testkit"))
         "org.bouncycastle" % "bcprov-jdk15on" % V.bouncyCastle % Runtime,
         "com.codecommit" %% "cats-effect-testing-scalatest-scalacheck" % V.catsEffectTestingScalatestScalacheck,
         "io.chrisdavenport" %% "log4cats-core" % "1.1.1",
-        "org.scalacheck" %% "scalacheck" % "1.15.1",
+        "org.scalacheck" %% "scalacheck" % "1.15.2",
         "org.scalactic" %% "scalactic" % "3.2.3",
         "org.scalatest" %% "scalatest-core" % "3.2.3",
         "org.scalatest" %% "scalatest-matchers-core" % "3.2.3",

--- a/build.sbt
+++ b/build.sbt
@@ -82,6 +82,7 @@ lazy val `fs2-pgp`: Project = (project in file("core"))
         "com.chuusai" %% "shapeless" % V.shapeless,
         "org.scala-lang.modules" %% "scala-collection-compat" % "2.2.0",
         "io.chrisdavenport" %% "log4cats-core" % log4catsV,
+        "eu.timepit" %% "refined" % V.refined,
       )
     },
     unusedCompileDependenciesFilter -= moduleFilter("org.scala-lang.modules", "scala-collection-compat"),
@@ -94,6 +95,7 @@ lazy val tests = (project in file("tests"))
       Seq(
         "org.scalatest" %% "scalatest" % V.scalaTest % Test,
         "com.codecommit" %% "cats-effect-testing-scalatest-scalacheck" % V.catsEffectTestingScalatestScalacheck % Test,
+        "eu.timepit" %% "refined-scalacheck" % V.refined % Test,
       )
     },
     skip in publish := true,
@@ -116,6 +118,8 @@ lazy val `pgp-testkit`: Project = (project in file("testkit"))
         "org.scalatestplus" %% "scalacheck-1-15" % "3.2.3.0",
         "org.typelevel" %% "cats-core" % V.cats,
         "org.typelevel" %% "cats-effect" % V.catsEffect,
+        "eu.timepit" %% "refined" % V.refined,
+        "com.chuusai" %% "shapeless" % V.shapeless,
       )
     },
   ) ++ commonSettings: _*)

--- a/core/src/main/scala/com/dwolla/security/crypto/StreamableOutputStream.scala
+++ b/core/src/main/scala/com/dwolla/security/crypto/StreamableOutputStream.scala
@@ -1,0 +1,51 @@
+package com.dwolla.security.crypto
+
+import cats.effect._
+import cats.effect.syntax.all._
+import cats.syntax.all._
+import fs2._
+import fs2.concurrent.Queue
+
+import java.io.OutputStream
+
+abstract class StreamableOutputStream[F[_]] extends OutputStream with AutoCloseable {
+  val stream: Stream[F, Byte]
+}
+
+object StreamableOutputStream {
+  def readOutputStream[F[_] : ConcurrentEffect : ContextShift](blocker: Blocker)
+                                                              (f: OutputStream => F[Unit]): Stream[F, Byte] =
+    Stream.resource(StreamableOutputStream[F](blocker)).flatMap { os =>
+      os.stream.concurrently(Stream.eval(f(os)) >> Stream.eval(Sync[F].delay(os.close())))
+    }
+
+  def apply[F[_] : ConcurrentEffect : ContextShift](blocker: Blocker): Resource[F, StreamableOutputStream[F]] =
+    Resource.fromAutoCloseableBlocking(blocker)(acquireSES[F])
+
+  private def acquireSES[F[_] : ConcurrentEffect]: F[StreamableOutputStream[F]] =
+    Queue.boundedNoneTerminated[F, Chunk[Byte]](1).map { queue =>
+      new StreamableOutputStream[F] {
+        override val stream: Stream[F, Byte] =
+          queue.dequeue.flatMap(Stream.chunk)
+
+        override def write(b: Int): Unit =
+          queue.enqueue1(Option(Chunk(b.toByte))).toIO.unsafeRunSync()
+
+        override def write(b: Array[Byte]): Unit =
+          queue.enqueue1(Option(Chunk.array(b))).toIO.unsafeRunSync()
+
+        override def write(b: Array[Byte], off: Int, len: Int): Unit =
+          if (null == b) throw new NullPointerException("the passed Array[Byte] must not be null")
+          else if (off < 0) throw new IndexOutOfBoundsException(s"offset must be greater than or equal to 0, but $off < 0")
+          else if (off > b.length) throw new IndexOutOfBoundsException(s"offset must be less than or equal to the buffer length ($off > ${b.length})")
+          else if (len < 0) throw new IndexOutOfBoundsException(s"the number of bytes to be written must be greater than or equal to 0, but $len < 0")
+          else if ((off + len) > b.length) throw new IndexOutOfBoundsException(s"the offset plus number of bytes to be written must be less than or equal to the length of the buffer, but ($off + $len) > ${b.length}")
+          else if ((off + len) < 0) throw new IndexOutOfBoundsException(s"the offset plus the number of bytes to be written must be greater than or equal to 0, but ($off + $len) < 0")
+          else if (0 == len) ()
+          else write(b.slice(off, off + len))
+
+        override def close(): Unit =
+          queue.enqueue1(None).toIO.unsafeRunSync()
+      }
+    }
+}

--- a/core/src/main/scala/com/dwolla/security/crypto/package.scala
+++ b/core/src/main/scala/com/dwolla/security/crypto/package.scala
@@ -1,12 +1,20 @@
 package com.dwolla.security
 
+import eu.timepit.refined.types.all._
+import eu.timepit.refined.auto._
+import eu.timepit.refined.predicates.all.Positive
+import eu.timepit.refined.refineV
 import shapeless.tag
 import shapeless.tag.@@
 import org.bouncycastle.openpgp.PGPLiteralData
 
 package object crypto {
-  type ChunkSize = Int @@ ChunkSizeTag
-  val defaultChunkSize: ChunkSize = tag[ChunkSizeTag][Int](4096)
+  type ChunkSize = PosInt @@ ChunkSizeTag
+
+  def tagChunkSize(pi: PosInt): ChunkSize = tag[ChunkSizeTag][PosInt](pi)
+  def attemptTagChunkSize(pi: Int): Either[String, ChunkSize] = refineV[Positive](pi).map(tagChunkSize)
+
+  val defaultChunkSize: ChunkSize = tagChunkSize(4096)
 }
 
 package crypto {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.5")
 addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.16")
 addSbtPlugin("com.github.cb372" % "sbt-explicit-dependencies" % "0.2.16")
-addSbtPlugin("com.codecommit" % "sbt-github-actions" % "0.9.5")
+addSbtPlugin("com.codecommit" % "sbt-github-actions" % "0.10.1")

--- a/tests/src/test/scala/com/dwolla/security/crypto/Fs2PgpSpec.scala
+++ b/tests/src/test/scala/com/dwolla/security/crypto/Fs2PgpSpec.scala
@@ -1,0 +1,17 @@
+package com.dwolla.security.crypto
+
+import cats.effect.{IO, Resource}
+import cats.effect.testing.scalatest.AsyncIOSpec
+import com.dwolla.testutils.{PgpArbitraries, ResourceCheckerAsserting}
+import org.scalatest.AsyncTestSuite
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.{CheckerAsserting, ScalaCheckPropertyChecks}
+
+trait Fs2PgpSpec
+  extends AsyncIOSpec
+    with Matchers
+    with ScalaCheckPropertyChecks
+    with PgpArbitraries { asyncTestSuite: AsyncTestSuite =>
+  protected implicit def ioCheckingAsserting[A]: CheckerAsserting[Resource[IO, A]] { type Result = IO[Unit] } =
+    new ResourceCheckerAsserting[IO, A]
+}

--- a/tests/src/test/scala/com/dwolla/security/crypto/StreamableOutputStreamSpec.scala
+++ b/tests/src/test/scala/com/dwolla/security/crypto/StreamableOutputStreamSpec.scala
@@ -1,0 +1,36 @@
+package com.dwolla.security.crypto
+
+import cats.effect._
+import fs2.{Pure, Stream}
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalatest.flatspec.AsyncFlatSpec
+
+class StreamableOutputStreamSpec
+  extends AsyncFlatSpec
+    with Fs2PgpSpec {
+
+  private implicit def arbBytes: Arbitrary[Stream[Pure, Byte]] = Arbitrary {
+    for {
+      count <- Gen.chooseNum(0, 20000000)
+      moreBytes <- Gen.listOfN(count, arbitrary[Byte])
+    } yield Stream.emits(moreBytes)
+  }
+
+  behavior of "StreamableOutputStream"
+
+  it should "stream out the bytes written in" in {
+    forAll { bytes: Stream[Pure, Byte] =>
+      val expected = bytes.compile.toVector
+
+      Blocker[IO].evalMap { blocker =>
+        StreamableOutputStream.readOutputStream[IO](blocker) { os =>
+          bytes.chunks.evalMap(c => IO(os.write(c.toArray))).compile.drain
+        }
+          .compile
+          .toVector
+          .map(_ should be(expected))
+      }
+    }
+  }
+}


### PR DESCRIPTION
BouncyCastle requires piping bytes through `OutputStream`s to do its work. fs2's `io.readOutputStream` method relies on Java's `PipedInputStream`, which has a long-standing wontfix bug, which means it doesn't work in an environment where the writing thread can change. Since we write into the `OutputStream` in managed effects, we don't have easy control over the writing thread, and in fact the current implementation doesn't work under load.

This should resolve that issue by using a custom `OutputStream` that writes data into a `Queue[F, Byte]`, which can then be read as a `Stream[F, Byte]`.