### PR TITLE
use 1 minute timeout for all ScalaCheck effectful tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ lazy val V = new {
   val fs2 = "2.5.8"
   val bouncyCastle = "1.69"
   val scalaTest = "3.2.3"
-  val catsEffectTestingScalatestScalacheck = "0.5.0"
+  val catsEffectTestingScalatestScalacheck = "0.5.4"
   val refined = "0.9.20"
   val shapeless = "2.3.7"
   val log4cats = "1.3.1"
@@ -108,11 +108,11 @@ lazy val `pgp-testkit`: Project = (project in file("testkit"))
         "org.bouncycastle" % "bcprov-jdk15on" % V.bouncyCastle % Runtime,
         "com.codecommit" %% "cats-effect-testing-scalatest-scalacheck" % V.catsEffectTestingScalatestScalacheck,
         "org.typelevel" %% "log4cats-core" % V.log4cats,
-        "org.scalacheck" %% "scalacheck" % "1.15.2",
-        "org.scalactic" %% "scalactic" % "3.2.3",
-        "org.scalatest" %% "scalatest-core" % "3.2.3",
-        "org.scalatest" %% "scalatest-matchers-core" % "3.2.3",
-        "org.scalatestplus" %% "scalacheck-1-15" % "3.2.3.0",
+        "org.scalacheck" %% "scalacheck" % "1.15.4",
+        "org.scalactic" %% "scalactic" % "3.2.9",
+        "org.scalatest" %% "scalatest-core" % "3.2.9",
+        "org.scalatest" %% "scalatest-matchers-core" % "3.2.9",
+        "org.scalatestplus" %% "scalacheck-1-15" % "3.2.9.0",
         "org.typelevel" %% "cats-core" % V.cats,
         "org.typelevel" %% "cats-effect" % V.catsEffect,
         "eu.timepit" %% "refined" % V.refined,

--- a/testkit/src/main/scala/com/dwolla/testutils/ResourceCheckerAsserting.scala
+++ b/testkit/src/main/scala/com/dwolla/testutils/ResourceCheckerAsserting.scala
@@ -1,23 +1,25 @@
 package com.dwolla.testutils
 
 import cats.effect._
-import cats.effect.testing.scalatest.scalacheck.EffectCheckerAsserting
 import cats.syntax.all._
-import cats.effect.syntax.all._
 import org.scalactic.source
 import org.scalatest.exceptions._
 import org.scalatestplus.scalacheck._
 
 import scala.concurrent.duration._
 
-class ResourceCheckerAsserting[F[_] : ConcurrentEffect : Timer, A](timeout: FiniteDuration = 1.minute) extends CheckerAsserting.CheckerAssertingImpl[Resource[F, A]] {
-  private val effectCheckerAsserting = new EffectCheckerAsserting[F, A]
+class ResourceCheckerAsserting[F[_] : ConcurrentEffect : Timer, A](timeout: FiniteDuration = 1.minute)
+  extends CheckerAsserting.CheckerAssertingImpl[Resource[F, A]] {
+
+  private val teca = new TimeoutEffectCheckerAsserting[F, A](timeout)
+
   override type Result = F[Unit]
 
   override def succeed(result: Resource[F, A]): (Boolean, Option[Throwable]) =
-    effectCheckerAsserting.succeed(result.use(x => x.pure[F]).timeout(timeout))
+    teca.succeed(result.use(x => x.pure[F]))
 
-  override def indicateSuccess(message: => String): Result = ().pure[F]
+  override def indicateSuccess(message: => String): Result =
+    teca.indicateSuccess(message)
 
   override def indicateFailure(messageFun: StackDepthException => String,
                                undecoratedMessage: => String,
@@ -26,15 +28,5 @@ class ResourceCheckerAsserting[F[_] : ConcurrentEffect : Timer, A](timeout: Fini
                                optionalCause: Option[Throwable],
                                pos: source.Position
                               ): Result =
-    new GeneratorDrivenPropertyCheckFailedException(
-      messageFun,
-      optionalCause,
-      pos,
-      None,
-      undecoratedMessage,
-      scalaCheckArgs,
-      None,
-      scalaCheckLabels
-    ).raiseError[F, Unit]
-
+    teca.indicateFailure(messageFun, undecoratedMessage, scalaCheckArgs, scalaCheckLabels, optionalCause, pos)
 }

--- a/testkit/src/main/scala/com/dwolla/testutils/TimeoutEffectCheckerAsserting.scala
+++ b/testkit/src/main/scala/com/dwolla/testutils/TimeoutEffectCheckerAsserting.scala
@@ -1,0 +1,15 @@
+package com.dwolla.testutils
+
+import cats.effect._
+import cats.effect.syntax.all._
+import cats.effect.testing.scalatest.scalacheck.EffectCheckerAsserting
+
+import scala.concurrent.duration._
+
+class TimeoutEffectCheckerAsserting[F[_] : ConcurrentEffect : Timer, A](timeout: FiniteDuration = 1.minute)
+  extends EffectCheckerAsserting[F, A] {
+
+  override def succeed(result: F[A]): (Boolean, Option[Throwable]) =
+    super.succeed(result.timeout(timeout))
+
+}

--- a/tests/src/test/scala/com/dwolla/security/crypto/Fs2PgpSpec.scala
+++ b/tests/src/test/scala/com/dwolla/security/crypto/Fs2PgpSpec.scala
@@ -1,9 +1,8 @@
 package com.dwolla.security.crypto
 
-import cats.effect.{Effect, IO, Resource}
+import cats.effect._
 import cats.effect.testing.scalatest.AsyncIOSpec
-import cats.effect.testing.scalatest.scalacheck.EffectCheckerAsserting
-import com.dwolla.testutils.{PgpArbitraries, ResourceCheckerAsserting}
+import com.dwolla.testutils.{PgpArbitraries, ResourceCheckerAsserting, TimeoutEffectCheckerAsserting}
 import org.scalatest.AsyncTestSuite
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.{CheckerAsserting, ScalaCheckPropertyChecks}
@@ -16,6 +15,6 @@ trait Fs2PgpSpec
   protected implicit def ioCheckingAsserting[A]: CheckerAsserting[Resource[IO, A]] { type Result = IO[Unit] } =
     new ResourceCheckerAsserting[IO, A]
 
-  protected implicit def effectCheckingAsserting[F[_] : Effect, A]: CheckerAsserting[F[A]] { type Result = F[Unit] } =
-    new EffectCheckerAsserting[F, A]
+  protected implicit def timeoutEffectCheckerAsserting[F[_] : ConcurrentEffect : Timer, A]: CheckerAsserting[F[A]] { type Result = F[Unit] } =
+    new TimeoutEffectCheckerAsserting[F, A]
 }


### PR DESCRIPTION
The tests in #12 are timing out, and I'm not sure why. I'm hoping this helps narrow it down.