### PR TITLE
Revert "Update log4cats-core to 2.1.1 (#28)"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ lazy val V = new {
   val catsEffectTestingScalatestScalacheck = "0.5.4"
   val refined = "0.9.27"
   val shapeless = "2.3.7"
-  val log4cats = "2.1.1"
+  val log4cats = "1.3.1"
   val catsScalacheck = "0.3.0"
   val scalaCollectionCompat = "2.5.0"
 }


### PR DESCRIPTION
This reverts commit 809096ad4bdadc8003966a894d3a94417dce971f. It should not have been merged yet, as it pulls in an update to cats-effect 3, for which this project is not yet ready.