### PR TITLE
LoggerFactory support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ lazy val V = new {
   val SCALA_2_12 = "2.12.15"
   val SCALA_2_13 = "2.13.8"
   val Scalas = Seq(SCALA_2_13, SCALA_2_12)
-  val bouncyCastle = "1.70"
+  val bouncyCastle = "1.71"
   val refined = "0.9.29"
   val shapeless = "2.3.9"
   val catsScalacheck = "0.3.0"
@@ -75,8 +75,8 @@ lazy val `fs2-pgp` = (project in file("core"))
         "org.typelevel" %% "cats-core" % V.cats,
         "org.typelevel" %% "cats-effect-kernel" % V.catsEffect,
         "org.typelevel" %% "cats-effect" % V.catsEffect,
-        "org.bouncycastle" % "bcpg-jdk15on" % V.bouncyCastle,
-        "org.bouncycastle" % "bcprov-jdk15on" % V.bouncyCastle,
+        "org.bouncycastle" % "bcpg-jdk18on" % V.bouncyCastle,
+        "org.bouncycastle" % "bcprov-jdk18on" % V.bouncyCastle,
         "co.fs2" %% "fs2-core" % V.fs2,
         "co.fs2" %% "fs2-io" % V.fs2,
         "com.chuusai" %% "shapeless" % V.shapeless,
@@ -116,8 +116,8 @@ lazy val `pgp-testkit` = (project in file("testkit"))
     description := "Scalacheck Arbitraries for PGP resources",
     libraryDependencies ++= {
       Seq(
-        "org.bouncycastle" % "bcpg-jdk15on" % V.bouncyCastle,
-        "org.bouncycastle" % "bcprov-jdk15on" % V.bouncyCastle % Runtime,
+        "org.bouncycastle" % "bcpg-jdk18on" % V.bouncyCastle,
+        "org.bouncycastle" % "bcprov-jdk18on" % V.bouncyCastle,
         "org.scalacheck" %% "scalacheck" % "1.16.0",
         "org.typelevel" %% "cats-core" % V.cats,
         "org.typelevel" %% "cats-effect-kernel" % V.catsEffect,

--- a/tests/src/test/scala/com/dwolla/security/crypto/CryptoAlgSpec.scala
+++ b/tests/src/test/scala/com/dwolla/security/crypto/CryptoAlgSpec.scala
@@ -11,7 +11,7 @@ import org.scalacheck.Arbitrary._
 import org.scalacheck._
 import org.scalacheck.effect.PropF.{forAllF, forAllNoShrinkF}
 import org.scalacheck.util.Pretty
-import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats._
 import org.typelevel.log4cats.noop.NoOpLogger
 import com.eed3si9n.expecty.Expecty.{ assert => Assert }
 
@@ -24,7 +24,10 @@ class CryptoAlgSpec
     with PgpArbitraries
     with CryptoArbitraries {
 
-  private implicit val noOpLogger: Logger[IO] = NoOpLogger[IO]
+  private implicit val noOpLogger: LoggerFactory[IO] = new LoggerFactory[IO] {
+    override def getLoggerFromName(name: String): SelfAwareStructuredLogger[IO] = NoOpLogger[IO]
+    override def fromName(name: String): IO[SelfAwareStructuredLogger[IO]] = NoOpLogger[IO].pure[IO]
+  }
 
   private val resource: Fixture[CryptoAlg[IO]] = ResourceSuiteLocalFixture("CryptoAlg[IO]", CryptoAlg[IO])
   override def munitFixtures = List(resource)

--- a/tests/src/test/scala/com/dwolla/security/crypto/PGPKeyAlgSpec.scala
+++ b/tests/src/test/scala/com/dwolla/security/crypto/PGPKeyAlgSpec.scala
@@ -14,7 +14,7 @@ import org.bouncycastle.openpgp.operator.jcajce.{JcaPGPContentSignerBuilder, Jca
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.effect.PropF.forAllF
-import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats._
 import org.typelevel.log4cats.noop.NoOpLogger
 import com.eed3si9n.expecty.Expecty.{assert => Assert}
 
@@ -25,7 +25,10 @@ class PGPKeyAlgSpec
     with ScalaCheckEffectSuite
     with PgpArbitraries
     with CryptoArbitraries {
-  private implicit val L: Logger[IO] = NoOpLogger[IO]
+  private implicit val L: LoggerFactory[IO] = new LoggerFactory[IO] {
+    override def getLoggerFromName(name: String): SelfAwareStructuredLogger[IO] = NoOpLogger[IO]
+    override def fromName(name: String): IO[SelfAwareStructuredLogger[IO]] = NoOpLogger[IO].pure[IO]
+  }
 
   test("PGPKeyAlg should load a PGPPublicKey from armored public key") {
     val key =


### PR DESCRIPTION
log4cats added a new capability trait called `LoggerFactory`, which represents the ability to create a named logger. This makes it easier for applications to have helpfully named loggers throughout the app, instead of having a single global logger used everywhere.

This PR changes the library's entry points from requiring `Logger[F]` to require `LoggerFactory[F]`. It sets a default logger name of `com.dwolla.security.crypto.CryptoAlg`, although this can be overridden by users.