### PR TITLE
group Bouncy Castle updates into a single PR

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,16 @@
+pullRequests.grouping = [
+  {
+    name = "bouncy_castle",
+    "title" = "Bouncy Castle updates",
+    "filter" = [
+      {
+        "group" = "org.bouncycastle",
+        "version" = "minor"
+      },
+      {
+        "group" = "org.bouncycastle",
+        "version" = "major"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
When a new major/minor version of Bouncy Castle is released, we want to merge all those updates at once. Hopefully this configures Scala Steward to group those updates into a single PR (which we'll then need to massage to make sure it's checking bincompat successfully).