### PR TITLE
Revert to Bouncy Castle 1.71

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -116,8 +116,6 @@ lazy val `pgp-testkit` = (project in file("testkit"))
     description := "Scalacheck Arbitraries for PGP resources",
     libraryDependencies ++= {
       Seq(
-        "org.bouncycastle" % "bcpg-jdk18on" % "1.72.2",
-        "org.bouncycastle" % "bcprov-jdk18on" % "1.72",
         "org.scalacheck" %% "scalacheck" % "1.17.0",
         "org.typelevel" %% "cats-core" % V.cats,
         "org.typelevel" %% "cats-effect-kernel" % V.catsEffect,
@@ -128,12 +126,12 @@ lazy val `pgp-testkit` = (project in file("testkit"))
         "io.chrisdavenport" %% "cats-scalacheck" % V.catsScalacheck,
         "co.fs2" %% "fs2-core" % V.fs2,
         "org.scala-lang.modules" %% "scala-collection-compat" % V.scalaCollectionCompat
-      )
+      ) ++ bouncyCastleArtifacts
     },
     unusedCompileDependenciesFilter -= moduleFilter("org.scala-lang.modules", "scala-collection-compat"),
   )
   .dependsOn(`fs2-pgp`)
-  .settings(commonSettings: _*)
+  .settings(commonSettings)
 
 lazy val `fs2-pgp-root` = (project in file("."))
   .settings(publishArtifact := false)

--- a/project/BouncyCastlePlugin.scala
+++ b/project/BouncyCastlePlugin.scala
@@ -24,8 +24,8 @@ object BouncyCastlePlugin extends AutoPlugin {
    * versions it was checked against.
    */
   lazy val modules = Seq(
-    ArtifactVersions("org.bouncycastle" % "bcpg-jdk18on" % "1.72.2", Seq("1.72.1")),
-    ArtifactVersions("org.bouncycastle" % "bcprov-jdk18on" % "1.72", Seq()),
+    ArtifactVersions("org.bouncycastle" % "bcpg-jdk18on" % "1.71", Seq()),
+    ArtifactVersions("org.bouncycastle" % "bcprov-jdk18on" % "1.71", Seq()),
   )
 
   private lazy val subprojects = modules.map { module =>


### PR DESCRIPTION
Later versions introduce binary incompatibilities and so should be released with major version bumps (or use a strategy like [Frameless](https://github.com/typelevel/frameless#versions-and-dependencies) or [http4s-scala-xml](https://github.com/http4s/http4s-scala-xml#http4s-scala-xml-1-1)).

(Merging this implies that I should not have approved #128, #138, or #144 without taking steps to ensure bincompat.)