### PR TITLE
Migrates to Scala 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13, 2.12]
+        scala: [3.3.0, 2.13, 2.12]
         java: [temurin@17]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
@@ -98,6 +98,16 @@ jobs:
       - name: sbt update
         if: matrix.java == 'temurin@17' && steps.setup-java-temurin-17.outputs.cache-hit == 'false'
         run: sbt reload +update
+
+      - name: Download target directories (3.3.0)
+        uses: actions/download-artifact@v3
+        with:
+          name: target-${{ matrix.os }}-${{ matrix.java }}-3.3.0
+
+      - name: Inflate target directories (3.3.0)
+        run: |
+          tar xf targets.tar
+          rm targets.tar
 
       - name: Download target directories (2.13)
         uses: actions/download-artifact@v3

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -12,6 +12,7 @@ pull_request_rules:
   - or:
     - body~=labels:.*early-semver-patch
     - body~=labels:.*early-semver-minor
+  - status-success=Build and Test (ubuntu-latest, 3.3.0, temurin@17)
   - status-success=Build and Test (ubuntu-latest, 2.13, temurin@17)
   - status-success=Build and Test (ubuntu-latest, 2.12, temurin@17)
   actions:

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,8 @@
 lazy val V = new {
   val SCALA_2_12 = "2.12.18"
   val SCALA_2_13 = "2.13.11"
-  val Scalas = Seq(SCALA_2_13, SCALA_2_12)
+  val SCALA_3    = "3.3.0"
+  val Scalas = Seq(SCALA_2_13, SCALA_2_12, SCALA_3)
 }
 
 ThisBuild / scalaVersion := V.Scalas.head
@@ -16,18 +17,25 @@ ThisBuild / developers := List(
     "Brian Holt",
     "bholt@dwolla.com",
     url("https://dwolla.com")
+  ),
+  Developer(
+    "cjsmith-0141",
+    "CJ Smith",
+    "cjs.connor.smith@gmail.com",
+    url("https://tazato.net")
   )
 )
 ThisBuild / githubWorkflowBuild := Seq(WorkflowStep.Sbt(List("test", "mimaReportBinaryIssues", "doc")))
 ThisBuild / tlJdkRelease := Option(8)
 ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("17"))
-ThisBuild / githubWorkflowScalaVersions := Seq("2.13", "2.12")
+ThisBuild / githubWorkflowScalaVersions := Seq("3.3.0", "2.13", "2.12")
 ThisBuild / tlCiReleaseBranches := Seq("main")
-ThisBuild / tlBaseVersion := "0.4"
+ThisBuild / tlBaseVersion := "0.5"
 ThisBuild / tlSonatypeUseLegacyHost := true
 ThisBuild / mergifyStewardConfig ~= {
   _.map(_.copy(mergeMinors = true, author = "dwolla-oss-scala-steward[bot]"))
 }
+ThisBuild / tlVersionIntroduced := Map("3" -> "0.5.0")
 
 lazy val `fs2-pgp-root` = (project in file("."))
   .settings(publishArtifact := false)

--- a/core/src/main/scala/com/dwolla/security/crypto/exceptions.scala
+++ b/core/src/main/scala/com/dwolla/security/crypto/exceptions.scala
@@ -6,7 +6,7 @@ import scala.annotation.nowarn
 import scala.runtime.{AbstractFunction1, AbstractFunction2}
 import scala.util.control.NoStackTrace
 
-class KeyRingMissingKeyException(expectedKeyId: Option[Long])
+class KeyRingMissingKeyException(val expectedKeyId: Option[Long])
   extends RuntimeException(s"Cannot decrypt message with the passed keyring because ${expectedKeyId.fold("it does not contain a compatible key and the message recipient is hidden")(id => s"it requires key $id, but the ring does not contain that key")}")
     with NoStackTrace
     with Product
@@ -24,12 +24,9 @@ class KeyRingMissingKeyException(expectedKeyId: Option[Long])
   @deprecated("only maintained for bincompat reasons", "0.4.0")
   override def canEqual(that: Any): Boolean = that.isInstanceOf[KeyRingMissingKeyException]
 
-  @deprecated("only maintained for bincompat reasons", "0.4.0")
-  def expectedKeyId(): Long = expectedKeyId.getOrElse(0)
-
   @nowarn
   @deprecated("only maintained for bincompat reasons", "0.4.0")
-  def copy(keyId: Long = expectedKeyId()): KeyRingMissingKeyException = KeyRingMissingKeyException(keyId)
+  def copy(keyId: Option[Long] = expectedKeyId): KeyRingMissingKeyException = KeyRingMissingKeyException(keyId)
 }
 
 object KeyRingMissingKeyException extends AbstractFunction1[Long, KeyRingMissingKeyException] {
@@ -39,10 +36,10 @@ object KeyRingMissingKeyException extends AbstractFunction1[Long, KeyRingMissing
 
   @deprecated("only maintained for bincompat reasons", "0.4.0")
   def unapply(arg: KeyRingMissingKeyException): Option[Long] =
-    arg.expectedKeyId().some
+    arg.expectedKeyId
 }
 
-class KeyMismatchException(expectedKeyId: Option[Long], val actualKeyId: Long)
+class KeyMismatchException(val expectedKeyId: Option[Long], val actualKeyId: Long)
   extends RuntimeException(s"Cannot decrypt message with key $actualKeyId${expectedKeyId.fold(". (The message recipient is hidden.)")(id => s" because it requires key $id")}")
     with NoStackTrace
     with Product
@@ -64,19 +61,16 @@ class KeyMismatchException(expectedKeyId: Option[Long], val actualKeyId: Long)
   @deprecated("only maintained for bincompat reasons", "0.4.0")
   override def canEqual(that: Any): Boolean = that.isInstanceOf[KeyMismatchException]
 
-  @deprecated("only maintained for bincompat reasons", "0.4.0")
-  def expectedKeyId(): Long = expectedKeyId.getOrElse(0)
-
   @nowarn
   @deprecated("only maintained for bincompat reasons", "0.4.0")
-  def copy(expectedKeyId: Long = this.expectedKeyId(), actualKeyId: Long = actualKeyId) =
-    new KeyMismatchException(Option(expectedKeyId).filter(_ == 0), actualKeyId)
+  def copy(expectedKeyId: Option[Long] = expectedKeyId, actualKeyId: Long = actualKeyId) =
+    new KeyMismatchException(expectedKeyId.filter(_ == 0), actualKeyId)
 }
 
 object KeyMismatchException extends AbstractFunction2[Long, Long, KeyMismatchException] {
   @deprecated("only maintained for bincompat reasons", "0.4.0")
   def unapply(arg: KeyMismatchException): Option[(Long, Long)] =
-    (arg.expectedKeyId(), arg.actualKeyId).some
+    (arg.expectedKeyId.getOrElse(0L), arg.actualKeyId).some
 
   def apply(expectedKeyId: Option[Long], actualKeyId: Long) = new KeyMismatchException(expectedKeyId, actualKeyId)
 

--- a/core/src/main/scala/com/dwolla/security/crypto/package.scala
+++ b/core/src/main/scala/com/dwolla/security/crypto/package.scala
@@ -1,24 +1,10 @@
 package com.dwolla.security
 
-import eu.timepit.refined.api.RefType
-import eu.timepit.refined.types.all._
-import eu.timepit.refined.auto._
-import eu.timepit.refined.predicates.all.Positive
-import eu.timepit.refined.refineV
-import shapeless.tag
-import shapeless.tag.@@
 import org.bouncycastle.openpgp.PGPLiteralData
 
 package object crypto {
-  type ChunkSize = PosInt @@ ChunkSizeTag
-
-  def tagChunkSize(pi: PosInt): ChunkSize = tag[ChunkSizeTag][PosInt](pi)
-  def attemptTagChunkSize(pi: Int): Either[String, ChunkSize] = refineV[Positive](pi).map(tagChunkSize)
-
-  val defaultChunkSize: ChunkSize = tagChunkSize(4096)
-
-  implicit def taggedAutoUnwrap[R[_, _], T, P, Tag](tp: R[T, P] @@ Tag)(implicit rt: RefType[R]): T =
-    rt.unwrap(tp)
+  val defaultChunkSize: Int = 4096
+  type ChunkSize = Int
 }
 
 package crypto {

--- a/project/BouncyCastlePlugin.scala
+++ b/project/BouncyCastlePlugin.scala
@@ -34,18 +34,25 @@ object BouncyCastlePlugin extends AutoPlugin {
   )
 
   private val commonSettings = Seq(
-    addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.13.2" cross CrossVersion.full),
-    addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.1"),
     Compile / scalacOptions ++= {
       CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, n)) if n >= 13 => "-Ymacro-annotations" :: Nil
+        case Some((2, n)) if n >= 13 => "-Ymacro-annotations" :: "-Xsource:3" :: Nil
         case _ => Nil
       }
     },
     libraryDependencies ++= {
       CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, n)) if n >= 13 => Nil
-        case _ => compilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full) :: Nil
+        case Some((2, n)) if n >= 13 => Seq(
+          compilerPlugin("org.typelevel" %% "kind-projector" % "0.13.2" cross CrossVersion.full),
+          compilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.1")
+        )
+        case _ => Seq()
+      }
+    },
+    libraryDependencies ++= {
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, n)) if n < 13 => Seq(compilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full))
+        case _ => Seq()
       }
     },
   )
@@ -75,10 +82,8 @@ object BouncyCastlePlugin extends AutoPlugin {
             "org.typelevel" %% "cats-effect" % "3.5.1",
             "co.fs2" %% "fs2-core" % "3.7.0",
             "co.fs2" %% "fs2-io" % "3.7.0",
-            "com.chuusai" %% "shapeless" % "2.3.10",
             "org.scala-lang.modules" %% "scala-collection-compat" % "2.11.0",
             "org.typelevel" %% "log4cats-core" % "2.6.0",
-            "eu.timepit" %% "refined" % "0.10.3",
             bouncyCastle,
           )
         },

--- a/testkit/src/main/scala/com/dwolla/testutils/CryptoArbitraries.scala
+++ b/testkit/src/main/scala/com/dwolla/testutils/CryptoArbitraries.scala
@@ -3,10 +3,6 @@ package com.dwolla.testutils
 import cats.effect._
 import cats.syntax.all._
 import com.dwolla.security.crypto._
-import eu.timepit.refined.api.Refined
-import eu.timepit.refined.auto._
-import eu.timepit.refined.numeric.Positive
-import eu.timepit.refined.scalacheck.all._
 import fs2._
 import org.bouncycastle.bcpg._
 import org.bouncycastle.openpgp._
@@ -29,9 +25,7 @@ trait CryptoArbitraries extends CryptoArbitrariesPlatform { self: PgpArbitraries
     genNBytesBetween(1 << 10, 1 << 20) // 1KB to 1MB
   }
 
-  implicit val arbChunkSize: Arbitrary[ChunkSize] = Arbitrary {
-    chooseRefinedNum[Refined, Int, Positive](1024, 4096).map(tagChunkSize)
-  }
+  implicit val arbChunkSize: Arbitrary[ChunkSize] = Arbitrary {4096 }
 
   override def genPgpBytes[F[_]](implicit A: Arbitrary[Resource[F, PGPKeyPair]]): Gen[Resource[F, Array[Byte]]] =
     for {

--- a/testkit/src/main/scala/com/dwolla/testutils/PgpArbitraries.scala
+++ b/testkit/src/main/scala/com/dwolla/testutils/PgpArbitraries.scala
@@ -5,10 +5,6 @@ import cats.effect._
 import cats.syntax.all._
 import com.dwolla.security.crypto.BouncyCastleResource
 import com.dwolla.testutils.PgpArbitraries.KeySize
-import eu.timepit.refined.W
-import eu.timepit.refined.api.Refined
-import eu.timepit.refined.auto._
-import eu.timepit.refined.predicates.all._
 import org.bouncycastle.bcpg.PublicKeyAlgorithmTags
 import org.bouncycastle.openpgp._
 import org.bouncycastle.openpgp.operator.jcajce.JcaPGPKeyPair
@@ -19,8 +15,7 @@ import java.security.KeyPairGenerator
 import java.util.Date
 
 trait PgpArbitraries extends PgpArbitrariesPlatform {
-  type KeySizePred = GreaterEqual[W.`384`.T]
-  type KeySize = Int Refined KeySizePred
+  type KeySize = Int 
 
   override implicit def arbPgpPublicKey[F[_]](implicit A: Arbitrary[Resource[F, PGPKeyPair]]): Arbitrary[Resource[F, PGPPublicKey]] = Arbitrary {
     arbitrary[Resource[F, PGPKeyPair]].map(_.map(_.getPublicKey))
@@ -48,7 +43,7 @@ trait PgpArbitraries extends PgpArbitrariesPlatform {
         for {
           generator <- Sync[F].blocking {
             val instance = KeyPairGenerator.getInstance("RSA", "BC")
-            instance.initialize(keySize.value)
+            instance.initialize(keySize)
             instance
           }
           pair <- Sync[F].delay {

--- a/tests/src/test/scala/com/dwolla/security/crypto/CryptoAlgSpec.scala
+++ b/tests/src/test/scala/com/dwolla/security/crypto/CryptoAlgSpec.scala
@@ -7,7 +7,7 @@ import fs2._
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.bouncycastle.bcpg._
 import org.bouncycastle.openpgp._
-import org.scalacheck.Arbitrary._
+import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck._
 import org.scalacheck.effect.PropF.{forAllF, forAllNoShrinkF}
 import org.scalacheck.util.Pretty
@@ -79,7 +79,7 @@ class CryptoAlgSpec
         encryptionChunkSize <- arbitrary[ChunkSize]
         // since the cryptotext is compressed, we need to generate at least 10x the chunk size to
         // be fairly confident that there will be at least one full-sized chunk
-        bytes <- genNBytesBetween(encryptionChunkSize.value * 10, 1 << 16)
+        bytes <- genNBytesBetween(encryptionChunkSize * 10, 1 << 16)
       } yield Inputs(keyPairR, encryptionChunkSize, bytes)
 
     forAllNoShrinkF(genChunkSizeTestInputs) { case Inputs(keyPairR, encryptionChunkSize, bytes) =>
@@ -97,7 +97,7 @@ class CryptoAlgSpec
         } yield chunkSizes
 
       testResource.use(chunkSizes => IO {
-        Assert(chunkSizes.contains(encryptionChunkSize.value))
+        Assert(chunkSizes.contains(encryptionChunkSize))
         Assert(Set(1, 2) contains chunkSizes.size)
       })
     }

--- a/tests/src/test/scala/com/dwolla/security/crypto/PGPKeyAlgSpec.scala
+++ b/tests/src/test/scala/com/dwolla/security/crypto/PGPKeyAlgSpec.scala
@@ -154,7 +154,7 @@ class PGPKeyAlgSpec
               new PGPSecretKey(PGPSignature.DEFAULT_CERTIFICATION, keyPair, "identity", sha1Calc, null, null, new JcaPGPContentSignerBuilder(keyPair.getPublicKey.getAlgorithm, HashAlgorithmTags.SHA256), new JcePBESecretKeyEncryptorBuilder(SymmetricKeyAlgorithmTags.AES_256, sha1Calc).setProvider("BC").build(passphrase))
             })
             armoredKey <-
-              readOutputStream(chunkSize.value) { os =>
+              readOutputStream(chunkSize) { os =>
                 IO.blocking(secretKey.encode(os))
               }
                 .through(crypto.armor())


### PR DESCRIPTION
- Remove shapeless
- Remove refined
- Add `-Xsource:3` to scala 2.13 compiler flags
- Remove some arbitraries from the test suite

The idea behind this change is to get to scala 3. This unfortunately needed some removal of very nice compilation time checks, but gains scala 3.