### PR TITLE
Support encrypting for multiple recipients (and add Scala 3 support)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13, 2.12]
+        scala: [3, 2.13, 2.12]
         java: [temurin@17]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
@@ -98,6 +98,16 @@ jobs:
       - name: sbt update
         if: matrix.java == 'temurin@17' && steps.setup-java-temurin-17.outputs.cache-hit == 'false'
         run: sbt +update
+
+      - name: Download target directories (3)
+        uses: actions/download-artifact@v3
+        with:
+          name: target-${{ matrix.os }}-${{ matrix.java }}-3
+
+      - name: Inflate target directories (3)
+        run: |
+          tar xf targets.tar
+          rm targets.tar
 
       - name: Download target directories (2.13)
         uses: actions/download-artifact@v3

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -12,6 +12,7 @@ pull_request_rules:
   - or:
     - body~=labels:.*early-semver-patch
     - body~=labels:.*early-semver-minor
+  - status-success=Build and Test (ubuntu-latest, 3, temurin@17)
   - status-success=Build and Test (ubuntu-latest, 2.13, temurin@17)
   - status-success=Build and Test (ubuntu-latest, 2.12, temurin@17)
   actions:

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,8 @@
 lazy val V = new {
   val SCALA_2_12 = "2.12.18"
   val SCALA_2_13 = "2.13.12"
-  val Scalas = Seq(SCALA_2_13, SCALA_2_12)
+  val SCALA_3 = "3.3.0"
+  val Scalas = Seq(SCALA_3, SCALA_2_13, SCALA_2_12)
 }
 
 ThisBuild / scalaVersion := V.Scalas.head
@@ -21,7 +22,7 @@ ThisBuild / developers := List(
 ThisBuild / githubWorkflowBuild := Seq(WorkflowStep.Sbt(List("test", "mimaReportBinaryIssues", "doc")))
 ThisBuild / tlJdkRelease := Option(8)
 ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("17"))
-ThisBuild / githubWorkflowScalaVersions := Seq("2.13", "2.12")
+ThisBuild / githubWorkflowScalaVersions := Seq("3", "2.13", "2.12")
 ThisBuild / tlCiReleaseBranches := Seq("main", "series/0.5")
 ThisBuild / tlBaseVersion := "0.5"
 ThisBuild / tlSonatypeUseLegacyHost := true

--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ ThisBuild / tlJdkRelease := Option(8)
 ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("17"))
 ThisBuild / githubWorkflowScalaVersions := Seq("2.13", "2.12")
 ThisBuild / tlCiReleaseBranches := Seq("main", "series/0.5")
-ThisBuild / tlBaseVersion := "0.4"
+ThisBuild / tlBaseVersion := "0.5"
 ThisBuild / tlSonatypeUseLegacyHost := true
 ThisBuild / mergifyStewardConfig ~= {
   _.map(_.copy(mergeMinors = true, author = "dwolla-oss-scala-steward[bot]"))

--- a/build.sbt
+++ b/build.sbt
@@ -32,4 +32,4 @@ ThisBuild / mergifyStewardConfig ~= {
 lazy val `fs2-pgp-root` = (project in file("."))
   .settings(publishArtifact := false)
   .enablePlugins(BouncyCastlePlugin)
-  .aggregate(BouncyCastlePlugin.aggregate)
+  .aggregate(BouncyCastlePlugin.extraProjects.map(_.project) *)

--- a/core/src/main/scala-2/com/dwolla/security/crypto/package-platform.scala
+++ b/core/src/main/scala-2/com/dwolla/security/crypto/package-platform.scala
@@ -1,0 +1,32 @@
+package com.dwolla.security
+
+import eu.timepit.refined.api.*
+import eu.timepit.refined.auto.*
+import eu.timepit.refined.predicates.all.*
+import eu.timepit.refined.refineV
+import eu.timepit.refined.types.all.*
+import monix.newtypes.*
+import org.typelevel.log4cats.Logger
+import fs2.Stream
+
+package object crypto {
+  type ChunkSize = ChunkSize.Type
+  object ChunkSize extends NewtypeWrapped[PosInt]
+
+  def attemptTagChunkSize(pi: Int): Either[String, ChunkSize] = refineV[Positive](pi).map(ChunkSize(_))
+
+  val defaultChunkSize: ChunkSize = ChunkSize(4096)
+  private[crypto] val objectIteratorChunkSize: ChunkSize = ChunkSize(1)
+
+  implicit class RefinedNewtypeOps[RNT](val refinedNewtype: RNT) extends AnyVal {
+    def unrefined[X, R[_, _], T, P](implicit
+                                    ex: HasExtractor.Aux[RNT, X],
+                                    x: X =:= R[T, P],
+                                    rt: RefType[R],
+                                   ): T = {
+      rt.unwrap(x(ex.extract(refinedNewtype)))
+    }
+  }
+
+  private[crypto] implicit def SLogger[F[_] : Logger]: Logger[Stream[F, *]] = Logger[F].mapK(Stream.functionKInstance[F])
+}

--- a/core/src/main/scala-3/com/dwolla/security/crypto/package-platform.scala
+++ b/core/src/main/scala-3/com/dwolla/security/crypto/package-platform.scala
@@ -1,0 +1,30 @@
+package com.dwolla.security.crypto
+
+import eu.timepit.refined.api.*
+import eu.timepit.refined.predicates.all.*
+import eu.timepit.refined.refineV
+import eu.timepit.refined.types.all.*
+import monix.newtypes.*
+import org.typelevel.log4cats.Logger
+import fs2.Stream
+import fs2.Stream.functionKInstance
+
+type ChunkSize = ChunkSize.Type
+object ChunkSize extends NewtypeWrapped[PosInt]
+
+def attemptTagChunkSize(pi: Int): Either[String, ChunkSize] = refineV[Positive](pi).map(ChunkSize(_))
+
+val defaultChunkSize: ChunkSize = ChunkSize(PosInt.unsafeFrom(4096)) // TODO refined macro
+private[crypto] val objectIteratorChunkSize: ChunkSize = ChunkSize(PosInt.unsafeFrom(1)) // TODO refined macro
+
+private[crypto] implicit class RefinedNewtypeOps[RNT](val refinedNewtype: RNT) extends AnyVal {
+  def unrefined[X, R[_, _], T, P](implicit
+                                  ex: HasExtractor.Aux[RNT, X],
+                                  x: X =:= R[T, P],
+                                  rt: RefType[R],
+                                 ): T = {
+    rt.unwrap(x(ex.extract(refinedNewtype)))
+  }
+}
+
+private[crypto] implicit def SLogger[F[_] : Logger]: Logger[Stream[F, *]] = Logger[F].mapK(Stream.functionKInstance[F])

--- a/core/src/main/scala/com/dwolla/security/crypto/Armor.scala
+++ b/core/src/main/scala/com/dwolla/security/crypto/Armor.scala
@@ -21,7 +21,7 @@ object Armor {
     private val closeStreamsAfterUse = false
 
     override def armor(chunkSize: ChunkSize): Pipe[F, Byte, Byte] = bytes =>
-      readOutputStream(chunkSize.value) { out =>
+      readOutputStream(chunkSize.unrefined) { out =>
         Stream.resource(Resource.fromAutoCloseable(Sync[F].blocking(new ArmoredOutputStream(out))))
           .flatMap { armorer =>
             bytes.through(writeOutputStream(armorer.pure[F].widen[OutputStream], closeStreamsAfterUse))

--- a/core/src/main/scala/com/dwolla/security/crypto/Armor.scala
+++ b/core/src/main/scala/com/dwolla/security/crypto/Armor.scala
@@ -1,12 +1,12 @@
 package com.dwolla.security.crypto
 
-import cats.effect._
-import cats.syntax.all._
-import fs2._
+import cats.effect.*
+import cats.syntax.all.*
+import fs2.*
 import fs2.io.{readOutputStream, writeOutputStream}
-import org.bouncycastle.bcpg._
+import org.bouncycastle.bcpg.*
 
-import java.io._
+import java.io.*
 import scala.annotation.nowarn
 
 trait Armor[F[_]] {

--- a/core/src/main/scala/com/dwolla/security/crypto/Armor.scala
+++ b/core/src/main/scala/com/dwolla/security/crypto/Armor.scala
@@ -1,0 +1,33 @@
+package com.dwolla.security.crypto
+
+import cats.effect._
+import cats.syntax.all._
+import fs2._
+import fs2.io.{readOutputStream, writeOutputStream}
+import org.bouncycastle.bcpg._
+
+import java.io._
+import scala.annotation.nowarn
+
+trait Armor[F[_]] {
+  def armor(chunkSize: ChunkSize): Pipe[F, Byte, Byte]
+
+  final def armor: Pipe[F, Byte, Byte] = armor(defaultChunkSize)
+}
+
+object Armor {
+  @nowarn("""msg=parameter (?:value )?ev in method apply is never used""")
+  def apply[F[_] : Async](implicit ev: BouncyCastleResource): Armor[F] = new Armor[F] {
+    private val closeStreamsAfterUse = false
+
+    override def armor(chunkSize: ChunkSize): Pipe[F, Byte, Byte] = bytes =>
+      readOutputStream(chunkSize.value) { out =>
+        Stream.resource(Resource.fromAutoCloseable(Sync[F].blocking(new ArmoredOutputStream(out))))
+          .flatMap { armorer =>
+            bytes.through(writeOutputStream(armorer.pure[F].widen[OutputStream], closeStreamsAfterUse))
+          }
+          .compile
+          .drain
+      }
+  }
+}

--- a/core/src/main/scala/com/dwolla/security/crypto/BouncyCastleResource.scala
+++ b/core/src/main/scala/com/dwolla/security/crypto/BouncyCastleResource.scala
@@ -1,11 +1,12 @@
 package com.dwolla.security.crypto
 
 import java.security.Security
-import cats.effect._
-import cats.syntax.all._
+import cats.effect.*
+import cats.syntax.all.*
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 
 import java.util.concurrent.atomic.AtomicInteger
+import scala.annotation.nowarn
 
 sealed trait BouncyCastleResource
 object BouncyCastleResource {
@@ -13,6 +14,10 @@ object BouncyCastleResource {
 
   private def register(provider: BouncyCastleProvider): Unit =
     synchronized {
+      @nowarn("msg=discarded non-Unit value of type Int")
+      def increment(): Unit =
+        timesBouncyCastleHasBeenRegistered.incrementAndGet()
+
       val previousCount = timesBouncyCastleHasBeenRegistered.getAndIncrement()
       val position = Security.addProvider(provider)
 
@@ -24,7 +29,7 @@ object BouncyCastleResource {
        * go out of scope.
        */
       if (position == -1 && previousCount == 0)
-        timesBouncyCastleHasBeenRegistered.incrementAndGet()
+        increment()
 
       ()
     }

--- a/core/src/main/scala/com/dwolla/security/crypto/CryptoAlg.scala
+++ b/core/src/main/scala/com/dwolla/security/crypto/CryptoAlg.scala
@@ -3,284 +3,40 @@ package com.dwolla.security.crypto
 import cats.data.NonEmptyList
 import cats.effect._
 import cats.syntax.all._
-import com.dwolla.security.crypto.Compression._
-import com.dwolla.security.crypto.DecryptToInputStream._
-import com.dwolla.security.crypto.Encryption._
-import com.dwolla.security.crypto.PgpLiteralDataPacketFormat._
-import eu.timepit.refined.auto._
 import fs2._
-import fs2.io.{readInputStream, readOutputStream, toInputStream, writeOutputStream}
-import org.bouncycastle.bcpg._
 import org.bouncycastle.openpgp._
-import org.bouncycastle.openpgp.operator.jcajce._
-import org.typelevel.log4cats.{Logger, LoggerFactory, LoggerName}
+import org.typelevel.log4cats.{LoggerFactory, LoggerName}
 
-import java.io._
-
-trait CryptoAlg[F[_]] {
-  def encrypt(key: PGPPublicKey,
-              moreKeys: PGPPublicKey*): Pipe[F, Byte, Byte] =
-    encrypt(NonEmptyList.of(key, moreKeys: _*), EncryptionConfig())
-
-  def encrypt(config: EncryptionConfig,
-              key: PGPPublicKey,
-              moreKeys: PGPPublicKey*): Pipe[F, Byte, Byte] =
-    encrypt(NonEmptyList.of(key, moreKeys: _*), config)
-
-  def encrypt(keys: NonEmptyList[PGPPublicKey],
-              config: EncryptionConfig): Pipe[F, Byte, Byte]
-
-  def decrypt(key: PGPPrivateKey,
-              chunkSize: ChunkSize,
-             ): Pipe[F, Byte, Byte]
-
-  def decrypt(keyring: PGPSecretKeyRing,
-              passphrase: Array[Char],
-              chunkSize: ChunkSize,
-             ): Pipe[F, Byte, Byte]
-
-  def decrypt(keyring: PGPSecretKeyRingCollection,
-              passphrase: Array[Char],
-              chunkSize: ChunkSize,
-             ): Pipe[F, Byte, Byte]
-
-  def armor(chunkSize: ChunkSize = defaultChunkSize): Pipe[F, Byte, Byte]
-
-  /* the rest of these definitions just provide default values for arguments */
-
-  final def decrypt(key: PGPPrivateKey): Pipe[F, Byte, Byte] =
-    decrypt(key, defaultChunkSize)
-
-  final def decrypt(keyring: PGPSecretKeyRing): Pipe[F, Byte, Byte] =
-    decrypt(keyring, Array.empty[Char], defaultChunkSize)
-
-  final def decrypt(keyring: PGPSecretKeyRing, passphrase: Array[Char]): Pipe[F, Byte, Byte] =
-    decrypt(keyring, passphrase, defaultChunkSize)
-
-  final def decrypt(keyring: PGPSecretKeyRing, chunkSize: ChunkSize): Pipe[F, Byte, Byte] =
-    decrypt(keyring, Array.empty[Char], chunkSize)
-
-  final def decrypt(keyring: PGPSecretKeyRingCollection): Pipe[F, Byte, Byte] =
-    decrypt(keyring, Array.empty[Char], defaultChunkSize)
-
-  final def decrypt(keyring: PGPSecretKeyRingCollection, passphrase: Array[Char]): Pipe[F, Byte, Byte] =
-    decrypt(keyring, passphrase, defaultChunkSize)
-
-  final def decrypt(keyring: PGPSecretKeyRingCollection, chunkSize: ChunkSize): Pipe[F, Byte, Byte] =
-    decrypt(keyring, Array.empty[Char], chunkSize)
-
-}
+trait CryptoAlg[F[_]]
+  extends Encrypt[F]
+    with Decrypt[F]
+    with Armor[F]
 
 object CryptoAlg {
-  private def addKeys[F[_] : Sync](pgpEncryptedDataGenerator: PGPEncryptedDataGenerator,
-                                   keys: NonEmptyList[PGPPublicKey]): F[Unit] =
-    keys.traverse_ { key =>
-      Sync[F].delay(pgpEncryptedDataGenerator.addMethod(new JcePublicKeyKeyEncryptionMethodGenerator(key)))
+  def resource[F[_] : Async : LoggerFactory]: Resource[F, CryptoAlg[F]] =
+    BouncyCastleResource[F].evalMap { implicit ev =>
+      CryptoAlg[F]
     }
 
-  private type PgpEncryptionPipelineComponents = (PGPEncryptedDataGenerator, PGPCompressedDataGenerator, PGPLiteralDataGenerator)
-
-  /**
-   * The order in which these armoring and generator resources are
-   * created matters, because they need to be closed in the right
-   * order for the encrypted data to be written out correctly.
-   */
-  private def pgpGenerators[F[_] : Sync](encryption: Encryption,
-                                         compression: Compression,
-                                        ): Resource[F, PgpEncryptionPipelineComponents] =
+  def apply[F[_] : Async : LoggerFactory](implicit ev: BouncyCastleResource): F[CryptoAlg[F]] =
     for {
-      pgpEncryptedDataGenerator <- Resource.make(Sync[F].blocking(new PGPEncryptedDataGenerator(new JcePGPDataEncryptorBuilder(encryption.tag).setWithIntegrityPacket(true))))(g => Sync[F].blocking(g.close()))
-      pgpCompressedDataGenerator <- Resource.make(Sync[F].blocking(new PGPCompressedDataGenerator(compression.tag)))(c => Sync[F].blocking(c.close()))
-      pgpLiteralDataGenerator <- Resource.make(Sync[F].blocking(new PGPLiteralDataGenerator()))(g => Sync[F].blocking(g.close()))
-    } yield (pgpEncryptedDataGenerator, pgpCompressedDataGenerator, pgpLiteralDataGenerator)
+      d <- LoggerFactory[F].create(LoggerName("com.dwolla.security.crypto.Decrypt")).map(implicit l => Decrypt[F])
+      e <- LoggerFactory[F].create(LoggerName("com.dwolla.security.crypto.Encrypt")).map(implicit l => Encrypt[F])
+      a = Armor[F]
+    } yield new CryptoAlg[F] {
+      override def encrypt(keys: NonEmptyList[PGPPublicKey], config: EncryptionConfig): Pipe[F, Byte, Byte] =
+        e.encrypt(keys, config)
 
-  /**
-   * This method takes an <code>OutputStream</code> that will essentially be the
-   * place where encrypted bytes are written, and returns an
-   * OutputStream that accepts plaintext for encryption.
-   *
-   * The data flow is as follows:
-   *
-   * Plaintext -> "Literal Data" Packetizer -> Compressor -> Encryptor -> OutputStream provided by caller
-   */
-  private[crypto] def encryptingOutputStream[F[_] : Sync](keys: NonEmptyList[PGPPublicKey],
-                                                          chunkSize: ChunkSize,
-                                                          fileName: Option[String],
-                                                          encryption: Encryption,
-                                                          compression: Compression,
-                                                          packetFormat: PgpLiteralDataPacketFormat,
-                                                          outputStreamIntoWhichToWriteEncryptedBytes: OutputStream): Resource[F, OutputStream] =
-    pgpGenerators[F](encryption, compression)
-      .evalTap { case (pgpEncryptedDataGenerator, _, _) =>
-        addKeys[F](pgpEncryptedDataGenerator, keys)
-      }
-      .evalMap { case (pgpEncryptedDataGenerator, pgpCompressedDataGenerator, pgpLiteralDataGenerator) =>
-        for {
-          now <- Clock[F].realTime.map(_.toMillis).map(new java.util.Date(_))
-          encryptor <- Sync[F].blocking(pgpEncryptedDataGenerator.open(outputStreamIntoWhichToWriteEncryptedBytes, Array.ofDim[Byte](chunkSize.value)))
-          compressor <- Sync[F].blocking(pgpCompressedDataGenerator.open(encryptor))
-          literalizer <- Sync[F].blocking(pgpLiteralDataGenerator.open(compressor, packetFormat.tag, fileName.getOrElse(PGPLiteralData.CONSOLE), now, Array.ofDim[Byte](chunkSize.value)))
-        } yield literalizer
-      }
+      override def armor(chunkSize: ChunkSize): Pipe[F, Byte, Byte] =
+        a.armor(chunkSize)
 
-  def apply[F[_] : Async : LoggerFactory](implicit loggerName: LoggerName = LoggerName("com.dwolla.security.crypto.CryptoAlg")): Resource[F, CryptoAlg[F]] =
-    BouncyCastleResource[F]
-      .evalMap(_ => LoggerFactory[F].create)
-      .map { implicit logger =>
-        new CryptoAlg[F] {
-          import scala.jdk.CollectionConverters._
+      override def decrypt(key: PGPPrivateKey, chunkSize: ChunkSize): Pipe[F, Byte, Byte] =
+        d.decrypt(key, chunkSize)
 
-          private implicit val SLogger: Logger[Stream[F, *]] = Logger[F].mapK(Stream.functionKInstance[F])
+      override def decrypt(keyring: PGPSecretKeyRing, passphrase: Array[Char], chunkSize: ChunkSize): Pipe[F, Byte, Byte] =
+        d.decrypt(keyring, passphrase, chunkSize)
 
-          private val fingerprintCalculator = new JcaKeyFingerprintCalculator
-          private val closeStreamsAfterUse = false
-
-          override def encrypt(keys: NonEmptyList[PGPPublicKey], config: EncryptionConfig): Pipe[F, Byte, Byte] =
-            _.through { bytes =>
-              readOutputStream(config.chunkSize.value) { outputStreamToRead =>
-                Logger[F].trace(s"${List.fill(keys.length)("🔑").mkString("")} encrypting input with ${keys.length} recipients") >>
-                  Stream
-                    .resource(encryptingOutputStream[F](keys, config.chunkSize, config.fileName, config.encryption, config.compression, config.packetFormat, outputStreamToRead))
-                    .flatMap(wos => bytes.chunkN(config.chunkSize.value).flatMap(Stream.chunk).through(writeOutputStream(wos.pure[F], closeStreamsAfterUse)))
-                    .compile
-                    .drain
-              }
-            }
-
-          private val objectIteratorChunkSize: ChunkSize = tagChunkSize(1)
-
-          private def pgpInputStreamToByteStream[A: DecryptToInputStream[F, *]](keylike: A,
-                                                                                chunkSize: ChunkSize): InputStream => Stream[F, Byte] = {
-            def pgpCompressedDataToBytes(pcd: PGPCompressedData): Stream[F, Byte] =
-              Logger[Stream[F, *]].trace("Found compressed data") >>
-                pgpInputStreamToByteStream(keylike, chunkSize).apply(pcd.getDataStream)
-
-            /*
-             * Literal data is not to be further processed, so its contents
-             * are the bytes to be read and output.
-             */
-            def pgpLiteralDataToBytes(pld: PGPLiteralData): Stream[F, Byte] =
-              Logger[Stream[F, *]].trace(s"found literal data for file: ${pld.getFileName} and format: ${pld.getFormat}") >>
-                readInputStream(Sync[F].blocking(pld.getDataStream), chunkSize.value)
-
-            def pgpEncryptedDataListToBytes(pedl: PGPEncryptedDataList): Stream[F, Byte] = {
-              Logger[Stream[F, *]].trace(s"found ${pedl.size()} encrypted data packets") >>
-                Stream.fromBlockingIterator[F](pedl.iterator().asScala, objectIteratorChunkSize)
-                  .evalMap[F, Option[InputStream]] {
-                    case pbe: PGPPublicKeyEncryptedData =>
-                      // a key ID of 0L indicates a "hidden" recipient,
-                      // and we can't use that key ID to lookup the key
-                      val recipientKeyId = Option(pbe.getKeyID).filterNot(_ == 0)
-
-                      // if the recipient is identified, check if it exists in the key material we have
-                      // if it does, or if the recipient is undefined, try to decrypt.
-                      if (recipientKeyId.exists(DecryptToInputStream[F, A].hasKeyId(keylike, _)) || recipientKeyId.isEmpty)
-                        pbe
-                          .decryptToInputStream(keylike, recipientKeyId)
-                          .map(_.pure[Option])
-                          .recoverWith {
-                            case ex: KeyRingMissingKeyException =>
-                              Logger[F]
-                                .trace(ex)(s"could not decrypt using key ${pbe.getKeyID}")
-                                .as(None)
-                            case ex: KeyMismatchException =>
-                              Logger[F]
-                                .trace(ex)(s"could not decrypt using key ${pbe.getKeyID}")
-                                .as(None)
-                          }
-                      else
-                        none[InputStream].pure[F]
-
-                    case other =>
-                      Logger[F].warn(EncryptionTypeError)(s"found wrong type of encrypted data: $other").as(None)
-                  }
-                  .unNone
-                  .head // if a value survived the unNone above, we have an InputStream we can work with, so move on
-                  .flatMap(pgpInputStreamToByteStream(keylike, chunkSize))
-            }
-
-            def ignore(s: String): Stream[F, Byte] =
-              Logger[Stream[F, *]].trace(s"ignoring $s") >> Stream.empty
-
-            pgpIS =>
-              Logger[Stream[F, *]].trace("starting pgpInputStreamToByteStream") >>
-                Stream.fromBlockingIterator[F](
-                  new PGPObjectFactory(pgpIS, fingerprintCalculator).iterator().asScala,
-                  objectIteratorChunkSize
-                )
-                  .flatMap {
-                    case _: PGPSignatureList => ignore("PGPSignatureList")
-                    case _: PGPSecretKeyRing => ignore("PGPSecretKeyRing")
-                    case _: PGPPublicKeyRing => ignore("PGPPublicKeyRing")
-                    case _: PGPPublicKey => ignore("PGPPublicKey")
-                    case x: PGPCompressedData => pgpCompressedDataToBytes(x)
-                    case x: PGPLiteralData => pgpLiteralDataToBytes(x)
-                    case x: PGPEncryptedDataList => pgpEncryptedDataListToBytes(x)
-                    case _: PGPOnePassSignatureList => ignore("PGPOnePassSignatureList")
-                    case _: PGPMarker => ignore("PGPMarker")
-                    case other => Logger[Stream[F, *]].warn(s"found unexpected $other") >> Stream.empty
-                  }
-          }
-
-          private def pipeToDecoderStream: Pipe[F, Byte, InputStream] =
-            _.through(toInputStream[F])
-              .evalTap(_ => Logger[F].trace("we have an InputStream containing the cryptotext"))
-              .evalMap { cryptoIS =>
-                Sync[F].blocking {
-                  PGPUtil.getDecoderStream(cryptoIS)
-                }
-              }
-
-          override def decrypt(keyring: PGPSecretKeyRingCollection,
-                               passphrase: Array[Char],
-                               chunkSize: ChunkSize): Pipe[F, Byte, Byte] =
-            _.through(pipeToDecoderStream)
-              .flatMap(pgpInputStreamToByteStream((keyring, passphrase), chunkSize))
-
-          override def decrypt(keyring: PGPSecretKeyRing,
-                               passphrase: Array[Char],
-                               chunkSize: ChunkSize): Pipe[F, Byte, Byte] =
-            _.through(pipeToDecoderStream)
-              .flatMap(pgpInputStreamToByteStream((keyring, passphrase), chunkSize))
-
-          override def decrypt(key: PGPPrivateKey, chunkSize: ChunkSize): Pipe[F, Byte, Byte] =
-            _.through(pipeToDecoderStream)
-              .flatMap(pgpInputStreamToByteStream(key, chunkSize))
-
-          private def writeToArmorer(armorer: OutputStream): Pipe[F, Byte, Unit] =
-            _.through(writeOutputStream(armorer.pure[F], closeStreamsAfterUse))
-
-          override def armor(chunkSize: ChunkSize): Pipe[F, Byte, Byte] = bytes =>
-            readOutputStream(chunkSize.value) { out =>
-              Stream.resource(Resource.fromAutoCloseable(Sync[F].blocking(new ArmoredOutputStream(out))))
-                .flatMap(writeToArmorer(_)(bytes))
-                .compile
-                .drain
-            }
-        }
-      }
-}
-
-class EncryptionConfig private(val chunkSize: ChunkSize,
-                               val fileName: Option[String],
-                               val encryption: Encryption,
-                               val compression: Compression,
-                               val packetFormat: PgpLiteralDataPacketFormat,
-                              ) {
-  private def copy(chunkSize: ChunkSize = this.chunkSize,
-                   fileName: Option[String] = this.fileName,
-                   encryption: Encryption = this.encryption,
-                   compression: Compression = this.compression,
-                   packetFormat: PgpLiteralDataPacketFormat = this.packetFormat): EncryptionConfig =
-    new EncryptionConfig(chunkSize, fileName, encryption, compression, packetFormat)
-
-  def withChunkSize(chunkSize: ChunkSize): EncryptionConfig = copy(chunkSize = chunkSize)
-  def withFileName(fileName: Option[String]): EncryptionConfig = copy(fileName = fileName)
-  def withEncryption(encryption: Encryption): EncryptionConfig = copy(encryption = encryption)
-  def withCompression(compression: Compression): EncryptionConfig = copy(compression = compression)
-  def withPacketFormat(packetFormat: PgpLiteralDataPacketFormat): EncryptionConfig = copy(packetFormat = packetFormat)
-}
-
-object EncryptionConfig {
-  def apply(): EncryptionConfig = new EncryptionConfig(defaultChunkSize, None, Aes256, Zip, Binary)
+      override def decrypt(keyring: PGPSecretKeyRingCollection, passphrase: Array[Char], chunkSize: ChunkSize): Pipe[F, Byte, Byte] =
+        d.decrypt(keyring, passphrase, chunkSize)
+    }
 }

--- a/core/src/main/scala/com/dwolla/security/crypto/Decrypt.scala
+++ b/core/src/main/scala/com/dwolla/security/crypto/Decrypt.scala
@@ -1,0 +1,160 @@
+package com.dwolla.security.crypto
+
+import cats.effect._
+import cats.syntax.all._
+import com.dwolla.security.crypto.DecryptToInputStream._
+import eu.timepit.refined.auto._
+import fs2._
+import fs2.io.{readInputStream, toInputStream}
+import org.bouncycastle.openpgp._
+import org.bouncycastle.openpgp.operator.jcajce._
+import org.typelevel.log4cats.{Logger, LoggerFactory}
+
+import java.io._
+import scala.annotation.nowarn
+
+trait Decrypt[F[_]] {
+  def decrypt(key: PGPPrivateKey,
+              chunkSize: ChunkSize,
+             ): Pipe[F, Byte, Byte]
+
+  def decrypt(keyring: PGPSecretKeyRing,
+              passphrase: Array[Char],
+              chunkSize: ChunkSize,
+             ): Pipe[F, Byte, Byte]
+
+  def decrypt(keyring: PGPSecretKeyRingCollection,
+              passphrase: Array[Char],
+              chunkSize: ChunkSize,
+             ): Pipe[F, Byte, Byte]
+
+  /* the rest of these definitions just provide default values for arguments */
+  final def decrypt(key: PGPPrivateKey): Pipe[F, Byte, Byte] =
+    decrypt(key, defaultChunkSize)
+
+  final def decrypt(keyring: PGPSecretKeyRing): Pipe[F, Byte, Byte] =
+    decrypt(keyring, Array.empty[Char], defaultChunkSize)
+
+  final def decrypt(keyring: PGPSecretKeyRing, passphrase: Array[Char]): Pipe[F, Byte, Byte] =
+    decrypt(keyring, passphrase, defaultChunkSize)
+
+  final def decrypt(keyring: PGPSecretKeyRing, chunkSize: ChunkSize): Pipe[F, Byte, Byte] =
+    decrypt(keyring, Array.empty[Char], chunkSize)
+
+  final def decrypt(keyring: PGPSecretKeyRingCollection): Pipe[F, Byte, Byte] =
+    decrypt(keyring, Array.empty[Char], defaultChunkSize)
+
+  final def decrypt(keyring: PGPSecretKeyRingCollection, passphrase: Array[Char]): Pipe[F, Byte, Byte] =
+    decrypt(keyring, passphrase, defaultChunkSize)
+
+  final def decrypt(keyring: PGPSecretKeyRingCollection, chunkSize: ChunkSize): Pipe[F, Byte, Byte] =
+    decrypt(keyring, Array.empty[Char], chunkSize)
+
+}
+
+object Decrypt {
+  @nowarn("""msg=parameter (?:value )?ev in method apply is never used""")
+  def apply[F[_] : Async : Logger : LoggerFactory](implicit ev: BouncyCastleResource): Decrypt[F] = new Decrypt[F] {
+    import scala.jdk.CollectionConverters._
+    private val objectIteratorChunkSize: ChunkSize = tagChunkSize(1)
+    private val fingerprintCalculator = new JcaKeyFingerprintCalculator
+
+    private def pgpInputStreamToByteStream[A: DecryptToInputStream[F, *]](keylike: A,
+                                                                          chunkSize: ChunkSize): InputStream => Stream[F, Byte] = {
+      def pgpCompressedDataToBytes(pcd: PGPCompressedData): Stream[F, Byte] =
+        Logger[Stream[F, *]].trace("Found compressed data") >>
+          pgpInputStreamToByteStream(keylike, chunkSize).apply(pcd.getDataStream)
+
+      /*
+       * Literal data is not to be further processed, so its contents
+       * are the bytes to be read and output.
+       */
+      def pgpLiteralDataToBytes(pld: PGPLiteralData): Stream[F, Byte] =
+        Logger[Stream[F, *]].trace(s"found literal data for file: ${pld.getFileName} and format: ${pld.getFormat}") >>
+          readInputStream(Sync[F].blocking(pld.getDataStream), chunkSize.value)
+
+      def pgpEncryptedDataListToBytes(pedl: PGPEncryptedDataList): Stream[F, Byte] = {
+        Logger[Stream[F, *]].trace(s"found ${pedl.size()} encrypted data packets") >>
+          Stream.fromBlockingIterator[F](pedl.iterator().asScala, objectIteratorChunkSize)
+            .evalMap[F, Option[InputStream]] {
+              case pbe: PGPPublicKeyEncryptedData =>
+                // a key ID of 0L indicates a "hidden" recipient,
+                // and we can't use that key ID to lookup the key
+                val recipientKeyId = Option(pbe.getKeyID).filterNot(_ == 0)
+
+                // if the recipient is identified, check if it exists in the key material we have
+                // if it does, or if the recipient is undefined, try to decrypt.
+                if (recipientKeyId.exists(DecryptToInputStream[F, A].hasKeyId(keylike, _)) || recipientKeyId.isEmpty)
+                  pbe
+                    .decryptToInputStream(keylike, recipientKeyId)
+                    .map(_.pure[Option])
+                    .recoverWith {
+                      case ex: KeyRingMissingKeyException =>
+                        Logger[F]
+                          .trace(ex)(s"could not decrypt using key ${pbe.getKeyID}")
+                          .as(None)
+                      case ex: KeyMismatchException =>
+                        Logger[F]
+                          .trace(ex)(s"could not decrypt using key ${pbe.getKeyID}")
+                          .as(None)
+                    }
+                else
+                  none[InputStream].pure[F]
+
+              case other =>
+                Logger[F].warn(EncryptionTypeError)(s"found wrong type of encrypted data: $other").as(None)
+            }
+            .unNone
+            .head // if a value survived the unNone above, we have an InputStream we can work with, so move on
+            .flatMap(pgpInputStreamToByteStream(keylike, chunkSize))
+      }
+
+      def ignore(s: String): Stream[F, Byte] =
+        Logger[Stream[F, *]].trace(s"ignoring $s") >> Stream.empty
+
+      pgpIS =>
+        Logger[Stream[F, *]].trace("starting pgpInputStreamToByteStream") >>
+          Stream.fromBlockingIterator[F](
+            new PGPObjectFactory(pgpIS, fingerprintCalculator).iterator().asScala,
+            objectIteratorChunkSize
+          )
+            .flatMap {
+              case _: PGPSignatureList => ignore("PGPSignatureList")
+              case _: PGPSecretKeyRing => ignore("PGPSecretKeyRing")
+              case _: PGPPublicKeyRing => ignore("PGPPublicKeyRing")
+              case _: PGPPublicKey => ignore("PGPPublicKey")
+              case x: PGPCompressedData => pgpCompressedDataToBytes(x)
+              case x: PGPLiteralData => pgpLiteralDataToBytes(x)
+              case x: PGPEncryptedDataList => pgpEncryptedDataListToBytes(x)
+              case _: PGPOnePassSignatureList => ignore("PGPOnePassSignatureList")
+              case _: PGPMarker => ignore("PGPMarker")
+              case other => Logger[Stream[F, *]].warn(s"found unexpected $other") >> Stream.empty
+            }
+    }
+
+    private def pipeToDecoderStream: Pipe[F, Byte, InputStream] =
+      _.through(toInputStream[F])
+        .evalTap(_ => Logger[F].trace("we have an InputStream containing the cryptotext"))
+        .evalMap { cryptoIS =>
+          Sync[F].blocking {
+            PGPUtil.getDecoderStream(cryptoIS)
+          }
+        }
+
+    override def decrypt(keyring: PGPSecretKeyRingCollection,
+                         passphrase: Array[Char],
+                         chunkSize: ChunkSize): Pipe[F, Byte, Byte] =
+      _.through(pipeToDecoderStream)
+        .flatMap(pgpInputStreamToByteStream((keyring, passphrase), chunkSize))
+
+    override def decrypt(keyring: PGPSecretKeyRing,
+                         passphrase: Array[Char],
+                         chunkSize: ChunkSize): Pipe[F, Byte, Byte] =
+      _.through(pipeToDecoderStream)
+        .flatMap(pgpInputStreamToByteStream((keyring, passphrase), chunkSize))
+
+    override def decrypt(key: PGPPrivateKey, chunkSize: ChunkSize): Pipe[F, Byte, Byte] =
+      _.through(pipeToDecoderStream)
+        .flatMap(pgpInputStreamToByteStream(key, chunkSize))
+  }
+}

--- a/core/src/main/scala/com/dwolla/security/crypto/Decrypt.scala
+++ b/core/src/main/scala/com/dwolla/security/crypto/Decrypt.scala
@@ -1,16 +1,15 @@
 package com.dwolla.security.crypto
 
-import cats.effect._
-import cats.syntax.all._
-import com.dwolla.security.crypto.DecryptToInputStream._
-import eu.timepit.refined.auto._
-import fs2._
+import cats.effect.*
+import cats.syntax.all.*
+import com.dwolla.security.crypto.DecryptToInputStream.*
+import fs2.*
 import fs2.io.{readInputStream, toInputStream}
-import org.bouncycastle.openpgp._
-import org.bouncycastle.openpgp.operator.jcajce._
+import org.bouncycastle.openpgp.*
+import org.bouncycastle.openpgp.operator.jcajce.*
 import org.typelevel.log4cats.{Logger, LoggerFactory}
 
-import java.io._
+import java.io.*
 import scala.annotation.nowarn
 
 trait Decrypt[F[_]] {
@@ -56,7 +55,6 @@ object Decrypt {
   @nowarn("""msg=parameter (?:value )?ev in method apply is never used""")
   def apply[F[_] : Async : Logger : LoggerFactory](implicit ev: BouncyCastleResource): Decrypt[F] = new Decrypt[F] {
     import scala.jdk.CollectionConverters._
-    private val objectIteratorChunkSize: ChunkSize = ChunkSize(1)
     private val fingerprintCalculator = new JcaKeyFingerprintCalculator
 
     private def pgpInputStreamToByteStream[A: DecryptToInputStream[F, *]](keylike: A,

--- a/core/src/main/scala/com/dwolla/security/crypto/DecryptToInputStream.scala
+++ b/core/src/main/scala/com/dwolla/security/crypto/DecryptToInputStream.scala
@@ -6,6 +6,7 @@ import cats.syntax.all._
 import fs2._
 import org.bouncycastle.openpgp._
 import org.bouncycastle.openpgp.operator.bc.{BcPBESecretKeyDecryptorBuilder, BcPGPDigestCalculatorProvider, BcPublicKeyDataDecryptorFactory}
+import org.typelevel.log4cats.{Logger, LoggerFactory, LoggerName}
 
 import java.io.InputStream
 import scala.jdk.CollectionConverters._
@@ -32,11 +33,11 @@ private[crypto] object DecryptToInputStream {
    * whose `InputStream` is read downstream. Once it finds a key that works, it will stop trying
    * any subsequent keys.
    */
-  private def decryptWithKeys[F[_] : Sync](input: List[PGPSecretKey],
-                                           passphrase: Array[Char],
-                                           pbed: PGPPublicKeyEncryptedData,
-                                           keyId: Option[Long],
-                                          ): F[InputStream] =
+  private def decryptWithKeys[F[_] : Sync : Logger](input: List[PGPSecretKey],
+                                                    passphrase: Array[Char],
+                                                    pbed: PGPPublicKeyEncryptedData,
+                                                    keyId: Option[Long],
+                                                   ): F[InputStream] =
     Stream
       .emits(input)
       .evalMap { secretKey =>
@@ -44,13 +45,18 @@ private[crypto] object DecryptToInputStream {
           val digestCalculatorProvider = new BcPGPDigestCalculatorProvider()
           val decryptor = new BcPBESecretKeyDecryptorBuilder(digestCalculatorProvider).build(passphrase)
           val key = secretKey.extractPrivateKey(decryptor)
-          new BcPublicKeyDataDecryptorFactory(key)
+          secretKey -> new BcPublicKeyDataDecryptorFactory(key)
         }
       }
-      .evalMap {
-        attemptDecrypt(pbed, _)
+      .evalMap { case (key, decryptorFactory) =>
+        attemptDecrypt(pbed, decryptorFactory)
           .map(_.some)
-          .handleError(_ => None)  // TODO should we log these failures at the TRACE level?
+          .handleErrorWith {
+            case t if keyId.contains(key.getKeyID) =>
+              Logger[F].trace(t)(s"an error occurred decrypting with what appears to be the correct key ID (${key.getKeyID}); ignoring and attempting to continue").as(None)
+            case _ =>
+              none.pure[F]
+          }
       }
       .unNone
       .head
@@ -60,27 +66,32 @@ private[crypto] object DecryptToInputStream {
         case _: NoSuchElementException => KeyRingMissingKeyException(keyId)
       }
 
-  implicit def PGPSecretKeyRingCollectionInstance[F[_] : Sync]: DecryptToInputStream[F, (PGPSecretKeyRingCollection, Array[Char])] =
+  implicit def PGPSecretKeyRingCollectionInstance[F[_] : Sync : LoggerFactory]: DecryptToInputStream[F, (PGPSecretKeyRingCollection, Array[Char])] =
     new DecryptToInputStream[F, (PGPSecretKeyRingCollection, Array[Char])] {
+
       override def hasKeyId(input: (PGPSecretKeyRingCollection, Array[Char]), id: Long): Boolean =
         input._1.contains(id)
 
       override def decryptToInputStream(input: (PGPSecretKeyRingCollection, Array[Char]),
                                         maybeKeyId: Option[Long])
                                        (pbed: PGPPublicKeyEncryptedData): F[InputStream] =
-        maybeKeyId
-          .toOptionT
-          .flatMapF { keyId =>
-            ApplicativeThrow[F].catchNonFatal {
-              Option(input._1.getSecretKey(keyId))
-            }
+        LoggerFactory[F]
+          .create(LoggerName("com.dwolla.security.crypto.DecryptToInputStream.PGPSecretKeyRingCollectionInstance"))
+          .flatMap { implicit logger =>
+            maybeKeyId
+              .toOptionT
+              .flatMapF { keyId =>
+                ApplicativeThrow[F].catchNonFatal {
+                  Option(input._1.getSecretKey(keyId))
+                }
+              }
+              .map(_.pure[List])
+              .getOrElse(input._1.getKeyRings.asScala.toList.flatMap(_.getSecretKeys.asScala))
+              .flatMap(decryptWithKeys(_, input._2, pbed, maybeKeyId))
           }
-          .map(_.pure[List])
-          .getOrElse(input._1.getKeyRings.asScala.toList.flatMap(_.getSecretKeys.asScala))
-          .flatMap(decryptWithKeys(_, input._2, pbed, maybeKeyId))
     }
 
-  implicit def PGPSecretKeyRingInstance[F[_] : Sync]: DecryptToInputStream[F, (PGPSecretKeyRing, Array[Char])] =
+  implicit def PGPSecretKeyRingInstance[F[_] : Sync : LoggerFactory]: DecryptToInputStream[F, (PGPSecretKeyRing, Array[Char])] =
     new DecryptToInputStream[F, (PGPSecretKeyRing, Array[Char])] {
       override def hasKeyId(input: (PGPSecretKeyRing, Array[Char]), id: Long): Boolean =
         input
@@ -96,7 +107,11 @@ private[crypto] object DecryptToInputStream {
           Option(input._1.getSecretKey(keyId)).toList
         }
 
-        decryptWithKeys(keys, input._2, pbed, maybeKeyId)
+        LoggerFactory[F]
+          .create(LoggerName("com.dwolla.security.crypto.DecryptToInputStream.PGPSecretKeyRingCollectionInstance"))
+          .flatMap { implicit logger =>
+            decryptWithKeys(keys, input._2, pbed, maybeKeyId)
+          }
       }
     }
 

--- a/core/src/main/scala/com/dwolla/security/crypto/Encrypt.scala
+++ b/core/src/main/scala/com/dwolla/security/crypto/Encrypt.scala
@@ -1,0 +1,124 @@
+package com.dwolla.security.crypto
+
+import cats.data.NonEmptyList
+import cats.effect._
+import cats.syntax.all._
+import com.dwolla.security.crypto.Compression.Zip
+import com.dwolla.security.crypto.Encryption.Aes256
+import com.dwolla.security.crypto.PgpLiteralDataPacketFormat.Binary
+import fs2._
+import fs2.io.{readOutputStream, writeOutputStream}
+import org.bouncycastle.openpgp._
+import org.bouncycastle.openpgp.operator.jcajce._
+import org.typelevel.log4cats.Logger
+
+import java.io._
+import scala.annotation.nowarn
+
+trait Encrypt[F[_]] {
+  final def encrypt(key: PGPPublicKey,
+                    moreKeys: PGPPublicKey*): Pipe[F, Byte, Byte] =
+    encrypt(NonEmptyList.of(key, moreKeys: _*), EncryptionConfig())
+
+  final def encrypt(config: EncryptionConfig,
+                    key: PGPPublicKey,
+                    moreKeys: PGPPublicKey*): Pipe[F, Byte, Byte] =
+    encrypt(NonEmptyList.of(key, moreKeys: _*), config)
+
+  def encrypt(keys: NonEmptyList[PGPPublicKey],
+              config: EncryptionConfig): Pipe[F, Byte, Byte]
+}
+
+object Encrypt {
+  private type PgpEncryptionPipelineComponents = (PGPEncryptedDataGenerator, PGPCompressedDataGenerator, PGPLiteralDataGenerator)
+
+  private def addKeys[F[_] : Sync](pgpEncryptedDataGenerator: PGPEncryptedDataGenerator,
+                                   keys: NonEmptyList[PGPPublicKey]): F[Unit] =
+    keys.traverse_ { key =>
+      Sync[F].delay(pgpEncryptedDataGenerator.addMethod(new JcePublicKeyKeyEncryptionMethodGenerator(key)))
+    }
+
+  /**
+   * The order in which these armoring and generator resources are
+   * created matters, because they need to be closed in the right
+   * order for the encrypted data to be written out correctly.
+   */
+  private def pgpGenerators[F[_] : Sync](encryption: Encryption,
+                                         compression: Compression,
+                                        ): Resource[F, PgpEncryptionPipelineComponents] =
+    for {
+      pgpEncryptedDataGenerator <- Resource.make(Sync[F].blocking(new PGPEncryptedDataGenerator(new JcePGPDataEncryptorBuilder(encryption.tag).setWithIntegrityPacket(true))))(g => Sync[F].blocking(g.close()))
+      pgpCompressedDataGenerator <- Resource.make(Sync[F].blocking(new PGPCompressedDataGenerator(compression.tag)))(c => Sync[F].blocking(c.close()))
+      pgpLiteralDataGenerator <- Resource.make(Sync[F].blocking(new PGPLiteralDataGenerator()))(g => Sync[F].blocking(g.close()))
+    } yield (pgpEncryptedDataGenerator, pgpCompressedDataGenerator, pgpLiteralDataGenerator)
+
+  /**
+   * This method takes an <code>OutputStream</code> that will essentially be the
+   * place where encrypted bytes are written, and returns an
+   * OutputStream that accepts plaintext for encryption.
+   *
+   * The data flow is as follows:
+   *
+   * Plaintext -> "Literal Data" Packetizer -> Compressor -> Encryptor -> OutputStream provided by caller
+   */
+  private[crypto] def encryptingOutputStream[F[_] : Sync](keys: NonEmptyList[PGPPublicKey],
+                                                          chunkSize: ChunkSize,
+                                                          fileName: Option[String],
+                                                          encryption: Encryption,
+                                                          compression: Compression,
+                                                          packetFormat: PgpLiteralDataPacketFormat,
+                                                          outputStreamIntoWhichToWriteEncryptedBytes: OutputStream): Resource[F, OutputStream] =
+    pgpGenerators[F](encryption, compression)
+      .evalTap { case (pgpEncryptedDataGenerator, _, _) =>
+        addKeys[F](pgpEncryptedDataGenerator, keys)
+      }
+      .evalMap { case (pgpEncryptedDataGenerator, pgpCompressedDataGenerator, pgpLiteralDataGenerator) =>
+        for {
+          now <- Clock[F].realTime.map(_.toMillis).map(new java.util.Date(_))
+          encryptor <- Sync[F].blocking(pgpEncryptedDataGenerator.open(outputStreamIntoWhichToWriteEncryptedBytes, Array.ofDim[Byte](chunkSize.value)))
+          compressor <- Sync[F].blocking(pgpCompressedDataGenerator.open(encryptor))
+          literalizer <- Sync[F].blocking(pgpLiteralDataGenerator.open(compressor, packetFormat.tag, fileName.getOrElse(PGPLiteralData.CONSOLE), now, Array.ofDim[Byte](chunkSize.value)))
+        } yield literalizer
+      }
+
+  @nowarn("""msg=parameter (?:value )?ev in method apply is never used""")
+  def apply[F[_] : Async : Logger](implicit ev: BouncyCastleResource): Encrypt[F] = new Encrypt[F] {
+    private val closeStreamsAfterUse = false
+
+    override def encrypt(keys: NonEmptyList[PGPPublicKey], config: EncryptionConfig): Pipe[F, Byte, Byte] =
+      _.through { bytes =>
+        readOutputStream(config.chunkSize.value) { outputStreamToRead =>
+          Logger[F].trace(s"${List.fill(keys.length)("🔑").mkString("")} encrypting input with ${keys.length} recipients") >>
+            Stream
+              .resource(encryptingOutputStream[F](keys, config.chunkSize, config.fileName, config.encryption, config.compression, config.packetFormat, outputStreamToRead))
+              .flatMap(wos => bytes.chunkN(config.chunkSize.value).flatMap(Stream.chunk).through(writeOutputStream(wos.pure[F], closeStreamsAfterUse)))
+              .compile
+              .drain
+        }
+      }
+  }
+}
+
+class EncryptionConfig private(val chunkSize: ChunkSize,
+                               val fileName: Option[String],
+                               val encryption: Encryption,
+                               val compression: Compression,
+                               val packetFormat: PgpLiteralDataPacketFormat,
+                              ) {
+  private def copy(chunkSize: ChunkSize = this.chunkSize,
+                   fileName: Option[String] = this.fileName,
+                   encryption: Encryption = this.encryption,
+                   compression: Compression = this.compression,
+                   packetFormat: PgpLiteralDataPacketFormat = this.packetFormat): EncryptionConfig =
+    new EncryptionConfig(chunkSize, fileName, encryption, compression, packetFormat)
+
+  def withChunkSize(chunkSize: ChunkSize): EncryptionConfig = copy(chunkSize = chunkSize)
+  def withFileName(fileName: Option[String]): EncryptionConfig = copy(fileName = fileName)
+  def withEncryption(encryption: Encryption): EncryptionConfig = copy(encryption = encryption)
+  def withCompression(compression: Compression): EncryptionConfig = copy(compression = compression)
+  def withPacketFormat(packetFormat: PgpLiteralDataPacketFormat): EncryptionConfig = copy(packetFormat = packetFormat)
+}
+
+object EncryptionConfig {
+  def apply(): EncryptionConfig = new EncryptionConfig(defaultChunkSize, None, Aes256, Zip, Binary)
+}

--- a/core/src/main/scala/com/dwolla/security/crypto/PGPKeyAlg.scala
+++ b/core/src/main/scala/com/dwolla/security/crypto/PGPKeyAlg.scala
@@ -16,10 +16,10 @@ trait PGPKeyAlg[F[_]] {
   def readSecretKeyCollection(keys: String): F[PGPSecretKeyRingCollection]
 }
 
-object PGPKeyAlg extends PGPKeyAlgPlatform {
+object PGPKeyAlg {
   private val keyChunkSize: Int = 1
 
-  override def apply[F[_] : Async]: PGPKeyAlg[F] = new PGPKeyAlg[F] {
+  def apply[F[_] : Async]: PGPKeyAlg[F] = new PGPKeyAlg[F] {
     import scala.jdk.CollectionConverters._
 
     override def readPublicKey(key: String): F[PGPPublicKey] =
@@ -81,10 +81,3 @@ object PGPKeyAlg extends PGPKeyAlgPlatform {
       } yield secretKey
   }
 }
-
-// only kept to maintain binary compatibility
-trait PGPKeyAlgPlatform {
-  private[crypto] def apply[F[_] : Async]: PGPKeyAlg[F] = PGPKeyAlg[F]
-}
-
-object PGPKeyAlgPlatform

--- a/core/src/main/scala/com/dwolla/security/crypto/exceptions.scala
+++ b/core/src/main/scala/com/dwolla/security/crypto/exceptions.scala
@@ -1,105 +1,24 @@
 package com.dwolla.security.crypto
 
-import cats.syntax.all._
-
-import scala.annotation.nowarn
-import scala.runtime.{AbstractFunction1, AbstractFunction2}
 import scala.util.control.NoStackTrace
 
-class KeyRingMissingKeyException(expectedKeyId: Option[Long])
+class KeyRingMissingKeyException private (expectedKeyId: Option[Long])
   extends RuntimeException(s"Cannot decrypt message with the passed keyring because ${expectedKeyId.fold("it does not contain a compatible key and the message recipient is hidden")(id => s"it requires key $id, but the ring does not contain that key")}")
     with NoStackTrace
-    with Product
-    with Equals
-    with Serializable {
-  @deprecated("only maintained for bincompat reasons", "0.4.0")
-  def this(keyId: Long) = this(keyId.some)
 
-  @deprecated("only maintained for bincompat reasons", "0.4.0")
-  override def productArity: Int = 1
-
-  @deprecated("only maintained for bincompat reasons", "0.4.0")
-  override def productElement(n: Int): Any = if (n == 0) expectedKeyId.getOrElse(0) else throw new IndexOutOfBoundsException()
-
-  @deprecated("only maintained for bincompat reasons", "0.4.0")
-  override def canEqual(that: Any): Boolean = that.isInstanceOf[KeyRingMissingKeyException]
-
-  @deprecated("only maintained for bincompat reasons", "0.4.0")
-  def expectedKeyId(): Long = expectedKeyId.getOrElse(0)
-
-  @nowarn
-  @deprecated("only maintained for bincompat reasons", "0.4.0")
-  def copy(keyId: Long = expectedKeyId()): KeyRingMissingKeyException = KeyRingMissingKeyException(keyId)
-}
-
-object KeyRingMissingKeyException extends AbstractFunction1[Long, KeyRingMissingKeyException] {
+object KeyRingMissingKeyException {
   def apply(expectedKeyId: Option[Long]) = new KeyRingMissingKeyException(expectedKeyId)
-  @deprecated("only maintained for bincompat reasons", "0.4.0")
-  override def apply(keyId: Long): KeyRingMissingKeyException = KeyRingMissingKeyException(keyId.some)
-
-  @deprecated("only maintained for bincompat reasons", "0.4.0")
-  def unapply(arg: KeyRingMissingKeyException): Option[Long] =
-    arg.expectedKeyId().some
 }
 
-class KeyMismatchException(expectedKeyId: Option[Long], val actualKeyId: Long)
+class KeyMismatchException private (expectedKeyId: Option[Long], val actualKeyId: Long)
   extends RuntimeException(s"Cannot decrypt message with key $actualKeyId${expectedKeyId.fold(". (The message recipient is hidden.)")(id => s" because it requires key $id")}")
     with NoStackTrace
-    with Product
-    with Equals
-    with Serializable {
-  @deprecated("only maintained for bincompat reasons", "0.4.0")
-  def this(expectedKeyId: Long, actualKeyId: Long) = this(Option(expectedKeyId).filter(_ == 0), actualKeyId)
 
-  @deprecated("only maintained for bincompat reasons", "0.4.0")
-  override def productArity: Int = 2
-
-  @deprecated("only maintained for bincompat reasons", "0.4.0")
-  override def productElement(n: Int): Any = n match {
-    case 0 => expectedKeyId.getOrElse(0)
-    case 1 => actualKeyId
-    case _ => throw new IndexOutOfBoundsException()
-  }
-
-  @deprecated("only maintained for bincompat reasons", "0.4.0")
-  override def canEqual(that: Any): Boolean = that.isInstanceOf[KeyMismatchException]
-
-  @deprecated("only maintained for bincompat reasons", "0.4.0")
-  def expectedKeyId(): Long = expectedKeyId.getOrElse(0)
-
-  @nowarn
-  @deprecated("only maintained for bincompat reasons", "0.4.0")
-  def copy(expectedKeyId: Long = this.expectedKeyId(), actualKeyId: Long = actualKeyId) =
-    new KeyMismatchException(Option(expectedKeyId).filter(_ == 0), actualKeyId)
-}
-
-object KeyMismatchException extends AbstractFunction2[Long, Long, KeyMismatchException] {
-  @deprecated("only maintained for bincompat reasons", "0.4.0")
-  def unapply(arg: KeyMismatchException): Option[(Long, Long)] =
-    (arg.expectedKeyId(), arg.actualKeyId).some
-
-  def apply(expectedKeyId: Option[Long], actualKeyId: Long) = new KeyMismatchException(expectedKeyId, actualKeyId)
-
-  override def apply(v1: Long, v2: Long): KeyMismatchException =
-    KeyMismatchException(v1.some, v2)
-
+object KeyMismatchException {
+  def apply(expectedKeyId: Option[Long], actualKeyId: Long) =
+    new KeyMismatchException(expectedKeyId, actualKeyId)
 }
 
 object EncryptionTypeError
   extends RuntimeException("encrypted data was not PGPPublicKeyEncryptedData")
     with NoStackTrace
-    with Product
-    with Equals
-    with Serializable {
-
-  @deprecated("only maintained for bincompat reasons", "0.4.0")
-  override def productArity: Int = 0
-
-  @deprecated("only maintained for bincompat reasons", "0.4.0")
-  override def productElement(n: Int): Any = throw new IndexOutOfBoundsException()
-
-  @deprecated("only maintained for bincompat reasons", "0.4.0")
-  override def canEqual(that: Any): Boolean = this == EncryptionTypeError
-
-  override def hashCode(): Int = super.hashCode()
-}

--- a/core/src/main/scala/com/dwolla/security/crypto/package.scala
+++ b/core/src/main/scala/com/dwolla/security/crypto/package.scala
@@ -5,9 +5,11 @@ import eu.timepit.refined.types.all._
 import eu.timepit.refined.auto._
 import eu.timepit.refined.predicates.all.Positive
 import eu.timepit.refined.refineV
+import fs2.Stream
 import shapeless.tag
 import shapeless.tag.@@
 import org.bouncycastle.openpgp.PGPLiteralData
+import org.typelevel.log4cats.Logger
 
 package object crypto {
   type ChunkSize = PosInt @@ ChunkSizeTag
@@ -19,6 +21,8 @@ package object crypto {
 
   implicit def taggedAutoUnwrap[R[_, _], T, P, Tag](tp: R[T, P] @@ Tag)(implicit rt: RefType[R]): T =
     rt.unwrap(tp)
+
+  private[crypto] implicit def SLogger[F[_] : Logger]: Logger[Stream[F, *]] = Logger[F].mapK(Stream.functionKInstance[F])
 }
 
 package crypto {

--- a/core/src/main/scala/com/dwolla/security/crypto/package.scala
+++ b/core/src/main/scala/com/dwolla/security/crypto/package.scala
@@ -1,33 +1,37 @@
 package com.dwolla.security
 
 import eu.timepit.refined.api.RefType
-import eu.timepit.refined.types.all._
-import eu.timepit.refined.auto._
+import eu.timepit.refined.auto.*
 import eu.timepit.refined.predicates.all.Positive
 import eu.timepit.refined.refineV
+import eu.timepit.refined.types.all.*
 import fs2.Stream
-import shapeless.tag
-import shapeless.tag.@@
+import monix.newtypes.*
 import org.bouncycastle.openpgp.PGPLiteralData
 import org.typelevel.log4cats.Logger
 
 package object crypto {
-  type ChunkSize = PosInt @@ ChunkSizeTag
+  type ChunkSize = ChunkSize.Type
+  object ChunkSize extends NewtypeWrapped[PosInt]
 
-  def tagChunkSize(pi: PosInt): ChunkSize = tag[ChunkSizeTag][PosInt](pi)
-  def attemptTagChunkSize(pi: Int): Either[String, ChunkSize] = refineV[Positive](pi).map(tagChunkSize)
+  def attemptTagChunkSize(pi: Int): Either[String, ChunkSize] = refineV[Positive](pi).map(ChunkSize(_))
 
-  val defaultChunkSize: ChunkSize = tagChunkSize(4096)
+  val defaultChunkSize: ChunkSize = ChunkSize(4096)
 
-  implicit def taggedAutoUnwrap[R[_, _], T, P, Tag](tp: R[T, P] @@ Tag)(implicit rt: RefType[R]): T =
-    rt.unwrap(tp)
+  implicit class RefinedNewtypeOps[RNT](val refinedNewtype: RNT) extends AnyVal {
+    def unrefined[X, R[_, _], T, P](implicit
+                                    ex: HasExtractor.Aux[RNT, X],
+                                    x: X =:= R[T, P],
+                                    rt: RefType[R],
+                                   ): T = {
+      rt.unwrap(x(ex.extract(refinedNewtype)))
+    }
+  }
 
   private[crypto] implicit def SLogger[F[_] : Logger]: Logger[Stream[F, *]] = Logger[F].mapK(Stream.functionKInstance[F])
 }
 
 package crypto {
-  trait ChunkSizeTag
-
   sealed trait Encryption {
     val tag: Int
   }

--- a/core/src/main/scala/com/dwolla/security/crypto/package.scala
+++ b/core/src/main/scala/com/dwolla/security/crypto/package.scala
@@ -1,75 +1,44 @@
-package com.dwolla.security
+package com.dwolla.security.crypto
 
-import eu.timepit.refined.api.RefType
-import eu.timepit.refined.auto.*
-import eu.timepit.refined.predicates.all.Positive
-import eu.timepit.refined.refineV
-import eu.timepit.refined.types.all.*
-import fs2.Stream
-import monix.newtypes.*
 import org.bouncycastle.openpgp.PGPLiteralData
-import org.typelevel.log4cats.Logger
 
-package object crypto {
-  type ChunkSize = ChunkSize.Type
-  object ChunkSize extends NewtypeWrapped[PosInt]
-
-  def attemptTagChunkSize(pi: Int): Either[String, ChunkSize] = refineV[Positive](pi).map(ChunkSize(_))
-
-  val defaultChunkSize: ChunkSize = ChunkSize(4096)
-
-  implicit class RefinedNewtypeOps[RNT](val refinedNewtype: RNT) extends AnyVal {
-    def unrefined[X, R[_, _], T, P](implicit
-                                    ex: HasExtractor.Aux[RNT, X],
-                                    x: X =:= R[T, P],
-                                    rt: RefType[R],
-                                   ): T = {
-      rt.unwrap(x(ex.extract(refinedNewtype)))
-    }
-  }
-
-  private[crypto] implicit def SLogger[F[_] : Logger]: Logger[Stream[F, *]] = Logger[F].mapK(Stream.functionKInstance[F])
+sealed trait Encryption {
+  val tag: Int
 }
 
-package crypto {
-  sealed trait Encryption {
-    val tag: Int
-  }
+object Encryption {
+  //    case object Idea extends Encryption { override val tag: Int = 1 }
+  //    case object TripleDes extends Encryption { override val tag: Int = 2 }
+  //    case object Cast5 extends Encryption { override val tag: Int = 3 }
+  //    case object Blowfish extends Encryption { override val tag: Int = 4 }
+  //    case object Safer extends Encryption { override val tag: Int = 5 }
+  //    case object Des extends Encryption { override val tag: Int = 6 }
+  //    case object Aes128 extends Encryption { override val tag: Int = 7 }
+  //    case object Aes192 extends Encryption { override val tag: Int = 8 }
+  case object Aes256 extends Encryption { override val tag: Int = 9 }
+  //    case object TwoFish extends Encryption { override val tag: Int = 10 }
+  //    case object Camellia128 extends Encryption { override val tag: Int = 11 }
+  //    case object Camellia192 extends Encryption { override val tag: Int = 12 }
+  //    case object Camellia256 extends Encryption { override val tag: Int = 13 }
+}
 
-  object Encryption {
-    //    case object Idea extends Encryption { override val tag: Int = 1 }
-    //    case object TripleDes extends Encryption { override val tag: Int = 2 }
-    //    case object Cast5 extends Encryption { override val tag: Int = 3 }
-    //    case object Blowfish extends Encryption { override val tag: Int = 4 }
-    //    case object Safer extends Encryption { override val tag: Int = 5 }
-    //    case object Des extends Encryption { override val tag: Int = 6 }
-    //    case object Aes128 extends Encryption { override val tag: Int = 7 }
-    //    case object Aes192 extends Encryption { override val tag: Int = 8 }
-    case object Aes256 extends Encryption { override val tag: Int = 9 }
-    //    case object TwoFish extends Encryption { override val tag: Int = 10 }
-    //    case object Camellia128 extends Encryption { override val tag: Int = 11 }
-    //    case object Camellia192 extends Encryption { override val tag: Int = 12 }
-    //    case object Camellia256 extends Encryption { override val tag: Int = 13 }
-  }
+sealed trait Compression {
+  val tag: Int
+}
 
-  sealed trait Compression {
-    val tag: Int
-  }
+object Compression {
+  case object Uncompressed extends Compression { override val tag: Int = 0 }
+  case object Zip extends Compression { override val tag: Int = 1 }
+  case object Zlib extends Compression { override val tag: Int = 2 }
+  case object Bzip2 extends Compression { override val tag: Int = 3 }
+}
 
-  object Compression {
-    case object Uncompressed extends Compression { override val tag: Int = 0 }
-    case object Zip extends Compression { override val tag: Int = 1 }
-    case object Zlib extends Compression { override val tag: Int = 2 }
-    case object Bzip2 extends Compression { override val tag: Int = 3 }
-  }
+sealed trait PgpLiteralDataPacketFormat {
+  val tag: Char
+}
 
-  sealed trait PgpLiteralDataPacketFormat {
-    val tag: Char
-  }
-
-  object PgpLiteralDataPacketFormat {
-    case object Binary extends PgpLiteralDataPacketFormat { override val tag: Char = PGPLiteralData.BINARY }
-    case object Text extends PgpLiteralDataPacketFormat { override val tag: Char = PGPLiteralData.TEXT }
-    case object Utf8 extends PgpLiteralDataPacketFormat { override val tag: Char = PGPLiteralData.UTF8 }
-  }
+object PgpLiteralDataPacketFormat {
+  case object Binary extends PgpLiteralDataPacketFormat { override val tag: Char = PGPLiteralData.BINARY }
+  case object Text extends PgpLiteralDataPacketFormat { override val tag: Char = PGPLiteralData.TEXT }
+  case object Utf8 extends PgpLiteralDataPacketFormat { override val tag: Char = PGPLiteralData.UTF8 }
 }

--- a/project/BouncyCastlePlugin.scala
+++ b/project/BouncyCastlePlugin.scala
@@ -1,5 +1,7 @@
 import com.typesafe.tools.mima.plugin.MimaKeys.*
 import explicitdeps.ExplicitDepsPlugin.autoImport.*
+import org.typelevel.sbt.TypelevelKernelPlugin.autoImport.*
+import org.typelevel.sbt.TypelevelSettingsPlugin
 import sbt.*
 import sbt.Keys.*
 
@@ -36,8 +38,13 @@ object BouncyCastlePlugin extends AutoPlugin {
   )
 
   private val commonSettings = Seq(
-    addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.13.2" cross CrossVersion.full),
-    addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.1"),
+    libraryDependencies ++= {
+      if (tlIsScala3.value) Seq.empty
+      else Seq(
+        compilerPlugin("org.typelevel" %% "kind-projector" % "0.13.2" cross CrossVersion.full),
+        compilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.1"),
+      )
+    },
     Compile / scalacOptions ++= {
       CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((2, n)) if n >= 13 => "-Ymacro-annotations" :: Nil
@@ -46,8 +53,8 @@ object BouncyCastlePlugin extends AutoPlugin {
     },
     libraryDependencies ++= {
       CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, n)) if n >= 13 => Nil
-        case _ => compilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full) :: Nil
+        case Some((2, n)) if n < 13 => compilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full) :: Nil
+        case _ => Nil
       }
     },
   )
@@ -99,6 +106,7 @@ object BouncyCastlePlugin extends AutoPlugin {
         }
       )
       .settings(commonSettings)
+      .enablePlugins(TypelevelSettingsPlugin)
 
     val testkit = project
       .in(adjustedFile("testkit"))
@@ -122,6 +130,7 @@ object BouncyCastlePlugin extends AutoPlugin {
       )
       .dependsOn(core)
       .settings(commonSettings)
+      .enablePlugins(TypelevelSettingsPlugin)
 
     val tests = project
       .in(adjustedFile("tests"))
@@ -147,6 +156,7 @@ object BouncyCastlePlugin extends AutoPlugin {
       )
       .dependsOn(core, testkit)
       .settings(commonSettings)
+      .enablePlugins(TypelevelSettingsPlugin)
 
     (core, testkit, tests)
   }

--- a/project/BouncyCastlePlugin.scala
+++ b/project/BouncyCastlePlugin.scala
@@ -159,14 +159,6 @@ object BouncyCastlePlugin extends AutoPlugin {
     List(c, tk, t)
   }
 
-  // TODO can we get rid of this project by adding the aggregated projects to the root project?
-  lazy val aggregate = Project("aggregate", file(".aggregate"))
-    .aggregate((List(core, testkit, tests) ++ oldVersionProjects).map(p => LocalProject(p.id)) *)
-    .settings(
-      publishArtifact := false,
-      publish / skip := true,
-    )
-
   override lazy val extraProjects: Seq[Project] =
-    Seq(aggregate, core, testkit, tests) ++ oldVersionProjects
+    Seq(core, testkit, tests) ++ oldVersionProjects
 }

--- a/project/BouncyCastlePlugin.scala
+++ b/project/BouncyCastlePlugin.scala
@@ -80,7 +80,7 @@ object BouncyCastlePlugin extends AutoPlugin {
             "com.chuusai" %% "shapeless" % "2.3.10",
             "org.scala-lang.modules" %% "scala-collection-compat" % "2.11.0",
             "org.typelevel" %% "log4cats-core" % "2.6.0",
-            "eu.timepit" %% "refined" % "0.10.3",
+            "eu.timepit" %% "refined" % "0.11.0",
             bouncyCastle,
           )
         },
@@ -111,7 +111,7 @@ object BouncyCastlePlugin extends AutoPlugin {
         libraryDependencies ++= {
           Seq(
             "org.scalacheck" %% "scalacheck" % "1.17.0",
-            "eu.timepit" %% "refined-scalacheck" % "0.10.3",
+            "eu.timepit" %% "refined-scalacheck" % "0.11.0",
             "io.chrisdavenport" %% "cats-scalacheck" % "0.3.2",
           )
         },

--- a/project/BouncyCastlePlugin.scala
+++ b/project/BouncyCastlePlugin.scala
@@ -132,6 +132,8 @@ object BouncyCastlePlugin extends AutoPlugin {
         libraryDependencies ++= {
           Seq(
             "org.typelevel" %% "log4cats-noop" % "2.6.0" % Test,
+            "org.typelevel" %% "log4cats-slf4j" % "2.6.0" % Test,
+            "ch.qos.logback" % "logback-classic" % "1.4.7" % Test,
             "org.scalameta" %% "munit" % "0.7.29" % Test,
             "org.typelevel" %% "scalacheck-effect" % "1.0.4" % Test,
             "org.typelevel" %% "scalacheck-effect-munit" % "1.0.4" % Test,

--- a/project/BouncyCastlePlugin.scala
+++ b/project/BouncyCastlePlugin.scala
@@ -77,7 +77,7 @@ object BouncyCastlePlugin extends AutoPlugin {
             "org.typelevel" %% "cats-effect" % "3.5.2",
             "co.fs2" %% "fs2-core" % "3.9.3",
             "co.fs2" %% "fs2-io" % "3.9.3",
-            "com.chuusai" %% "shapeless" % "2.3.10",
+            "io.monix" %% "newtypes-core" % "0.2.3",
             "org.scala-lang.modules" %% "scala-collection-compat" % "2.11.0",
             "org.typelevel" %% "log4cats-core" % "2.6.0",
             "eu.timepit" %% "refined" % "0.11.0",

--- a/testkit/src/main/scala-2/com/dwolla/testutils/CryptoArbitrariesPlatform.scala
+++ b/testkit/src/main/scala-2/com/dwolla/testutils/CryptoArbitrariesPlatform.scala
@@ -1,0 +1,9 @@
+package com.dwolla.testutils
+
+import eu.timepit.refined.auto.*
+import eu.timepit.refined.types.all.*
+
+private[testutils] trait CryptoArbitrariesPlatform { self: CryptoArbitraries =>
+  protected val PosInt1024: PosInt = 1024
+  protected val PosInt4096: PosInt = 4096
+}

--- a/testkit/src/main/scala-2/com/dwolla/testutils/PgpArbitrariesPlatform.scala
+++ b/testkit/src/main/scala-2/com/dwolla/testutils/PgpArbitrariesPlatform.scala
@@ -1,0 +1,13 @@
+package com.dwolla.testutils
+
+import eu.timepit.refined.W
+import eu.timepit.refined.auto.*
+import eu.timepit.refined.predicates.all.*
+
+private[testutils] trait PgpArbitrariesPlatform { self: PgpArbitraries =>
+  type KeySizePred = GreaterEqual[W.`384`.T]
+
+  protected val KeySize512: KeySize = 512
+  protected val KeySize2048: KeySize = 2048
+  protected val KeySize4096: KeySize = 4096
+}

--- a/testkit/src/main/scala-3/com/dwolla/testutils/CryptoArbitrariesPlatform.scala
+++ b/testkit/src/main/scala-3/com/dwolla/testutils/CryptoArbitrariesPlatform.scala
@@ -1,0 +1,10 @@
+package com.dwolla.testutils
+
+import eu.timepit.refined.types.all.*
+
+private[testutils] trait CryptoArbitrariesPlatform { self: CryptoArbitraries =>
+
+  // TODO refined macro
+  protected val PosInt1024: PosInt = PosInt.unsafeFrom(1024)
+  protected val PosInt4096: PosInt = PosInt.unsafeFrom(4096)
+}

--- a/testkit/src/main/scala-3/com/dwolla/testutils/PgpArbitrariesPlatform.scala
+++ b/testkit/src/main/scala-3/com/dwolla/testutils/PgpArbitrariesPlatform.scala
@@ -1,0 +1,12 @@
+package com.dwolla.testutils
+
+import eu.timepit.refined.predicates.all._
+
+private[testutils] trait PgpArbitrariesPlatform { self: PgpArbitraries =>
+  type KeySizePred = GreaterEqual[384]
+
+  // TODO refined macros
+  protected val KeySize512: KeySize = KeySize.unsafeFrom(512)
+  protected val KeySize2048: KeySize = KeySize.unsafeFrom(2048)
+  protected val KeySize4096: KeySize = KeySize.unsafeFrom(4096)
+}

--- a/testkit/src/main/scala/com/dwolla/testutils/CryptoArbitraries.scala
+++ b/testkit/src/main/scala/com/dwolla/testutils/CryptoArbitraries.scala
@@ -1,24 +1,24 @@
 package com.dwolla.testutils
 
-import cats.effect._
-import cats.syntax.all._
-import com.dwolla.security.crypto._
+import cats.effect.*
+import cats.syntax.all.*
+import com.dwolla.security.crypto.*
 import eu.timepit.refined.api.Refined
-import eu.timepit.refined.auto._
 import eu.timepit.refined.numeric.Positive
-import eu.timepit.refined.scalacheck.all._
-import fs2._
-import org.bouncycastle.bcpg._
-import org.bouncycastle.openpgp._
-import org.bouncycastle.openpgp.operator._
+import eu.timepit.refined.scalacheck.all.*
+import fs2.*
+import org.bouncycastle.bcpg.*
+import org.bouncycastle.openpgp.*
+import org.bouncycastle.openpgp.operator.*
 import org.bouncycastle.openpgp.operator.jcajce.{JcaPGPContentSignerBuilder, JcaPGPDigestCalculatorProviderBuilder, JcePBESecretKeyEncryptorBuilder}
-import org.scalacheck.Arbitrary._
-import org.scalacheck._
-import org.scalacheck.cats.implicits._
+import org.scalacheck.Arbitrary.*
+import org.scalacheck.*
+import org.scalacheck.cats.implicits.*
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
-trait CryptoArbitraries { self: PgpArbitraries =>
+trait CryptoArbitraries
+  extends CryptoArbitrariesPlatform { self: PgpArbitraries =>
   def genNBytesBetween(min: Int, max: Int): Gen[Stream[Pure, Byte]] =
     for {
       count <- Gen.chooseNum(min, Math.max(min, max))
@@ -30,7 +30,7 @@ trait CryptoArbitraries { self: PgpArbitraries =>
   }
 
   implicit val arbChunkSize: Arbitrary[ChunkSize] = Arbitrary {
-    chooseRefinedNum[Refined, Int, Positive](1024, 4096).map(ChunkSize(_))
+    chooseRefinedNum[Refined, Int, Positive](PosInt1024, PosInt4096).map(ChunkSize(_))
   }
 
   def genPgpBytes[F[_]](implicit A: Arbitrary[Resource[F, PGPKeyPair]]): Gen[Resource[F, Array[Byte]]] =

--- a/testkit/src/main/scala/com/dwolla/testutils/CryptoArbitraries.scala
+++ b/testkit/src/main/scala/com/dwolla/testutils/CryptoArbitraries.scala
@@ -30,7 +30,7 @@ trait CryptoArbitraries { self: PgpArbitraries =>
   }
 
   implicit val arbChunkSize: Arbitrary[ChunkSize] = Arbitrary {
-    chooseRefinedNum[Refined, Int, Positive](1024, 4096).map(tagChunkSize)
+    chooseRefinedNum[Refined, Int, Positive](1024, 4096).map(ChunkSize(_))
   }
 
   def genPgpBytes[F[_]](implicit A: Arbitrary[Resource[F, PGPKeyPair]]): Gen[Resource[F, Array[Byte]]] =

--- a/testkit/src/main/scala/com/dwolla/testutils/PgpArbitraries.scala
+++ b/testkit/src/main/scala/com/dwolla/testutils/PgpArbitraries.scala
@@ -18,31 +18,31 @@ import org.scalacheck._
 import java.security.KeyPairGenerator
 import java.util.Date
 
-trait PgpArbitraries extends PgpArbitrariesPlatform {
+trait PgpArbitraries {
   type KeySizePred = GreaterEqual[W.`384`.T]
   type KeySize = Int Refined KeySizePred
 
-  override implicit def arbPgpPublicKey[F[_]](implicit A: Arbitrary[Resource[F, PGPKeyPair]]): Arbitrary[Resource[F, PGPPublicKey]] = Arbitrary {
+  implicit def arbPgpPublicKey[F[_]](implicit A: Arbitrary[Resource[F, PGPKeyPair]]): Arbitrary[Resource[F, PGPPublicKey]] = Arbitrary {
     arbitrary[Resource[F, PGPKeyPair]].map(_.map(_.getPublicKey))
   }
 
-  override implicit def arbPgpPrivateKey[F[_]](implicit A: Arbitrary[Resource[F, PGPKeyPair]]): Arbitrary[Resource[F, PGPPrivateKey]] = Arbitrary {
+  implicit def arbPgpPrivateKey[F[_]](implicit A: Arbitrary[Resource[F, PGPKeyPair]]): Arbitrary[Resource[F, PGPPrivateKey]] = Arbitrary {
     arbitrary[Resource[F, PGPKeyPair]].map(_.map(_.getPrivateKey))
   }
 
-  override def genStrongKeyPair[F[_] : Sync]: Gen[Resource[F, PGPKeyPair]] =
+  def genStrongKeyPair[F[_] : Sync]: Gen[Resource[F, PGPKeyPair]] =
     for {
       keySize <- Gen.oneOf[KeySize](2048, 4096)
       keyPair <- genKeyPair[F](keySize)
     } yield keyPair
 
-  override def arbWeakKeyPair[F[_] : Sync]: Arbitrary[Resource[F, PGPKeyPair]] =
+  def arbWeakKeyPair[F[_] : Sync]: Arbitrary[Resource[F, PGPKeyPair]] =
     Arbitrary(genWeakKeyPair)
 
-  override def genWeakKeyPair[F[_] : Sync]: Gen[Resource[F, PGPKeyPair]] =
+  def genWeakKeyPair[F[_] : Sync]: Gen[Resource[F, PGPKeyPair]] =
     genKeyPair[F](512)
 
-  override def genKeyPair[F[_] : Sync](keySize: KeySize): Gen[Resource[F, PGPKeyPair]] =
+  def genKeyPair[F[_] : Sync](keySize: KeySize): Gen[Resource[F, PGPKeyPair]] =
     BouncyCastleResource[F]
       .evalMap { _ =>
         for {
@@ -63,13 +63,3 @@ trait PgpArbitraries extends PgpArbitrariesPlatform {
 }
 
 object PgpArbitraries extends PgpArbitraries
-
-// only kept to maintain binary compatibility
-trait PgpArbitrariesPlatform {
-  private[testutils] def arbPgpPublicKey[F[_]](implicit A: Arbitrary[Resource[F, PGPKeyPair]]): Arbitrary[Resource[F, PGPPublicKey]] = PgpArbitraries.arbPgpPublicKey
-  private[testutils] def arbPgpPrivateKey[F[_]](implicit A: Arbitrary[Resource[F, PGPKeyPair]]): Arbitrary[Resource[F, PGPPrivateKey]] = PgpArbitraries.arbPgpPrivateKey
-  private[testutils] def genStrongKeyPair[F[_] : Sync]: Gen[Resource[F, PGPKeyPair]] = PgpArbitraries.genStrongKeyPair
-  private[testutils] def arbWeakKeyPair[F[_] : Sync]: Arbitrary[Resource[F, PGPKeyPair]] = PgpArbitraries.arbWeakKeyPair
-  private[testutils] def genWeakKeyPair[F[_] : Sync]: Gen[Resource[F, PGPKeyPair]] = PgpArbitraries.genWeakKeyPair
-  private[testutils] def genKeyPair[F[_] : Sync](keySize: KeySize): Gen[Resource[F, PGPKeyPair]] = PgpArbitraries.genKeyPair(keySize)
-}

--- a/tests/src/test/resources/logback-test.xml
+++ b/tests/src/test/resources/logback-test.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%date | logger=%logger | '%msg'%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="ERROR">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/tests/src/test/scala/com/dwolla/security/crypto/ArmorSpec.scala
+++ b/tests/src/test/scala/com/dwolla/security/crypto/ArmorSpec.scala
@@ -1,0 +1,52 @@
+package com.dwolla.security.crypto
+
+import cats.effect._
+import com.dwolla.testutils._
+import fs2._
+import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
+import org.bouncycastle.bcpg._
+import org.bouncycastle.openpgp._
+import org.scalacheck._
+import org.scalacheck.effect.PropF.forAllF
+import org.typelevel.log4cats._
+import org.typelevel.log4cats.slf4j.Slf4jFactory
+
+import java.io.ByteArrayOutputStream
+
+class ArmorSpec
+  extends CatsEffectSuite
+    with ScalaCheckEffectSuite
+    with PgpArbitraries
+    with CryptoArbitraries {
+
+  private implicit val loggerFactory: LoggerFactory[IO] = Slf4jFactory.create[IO]
+
+  private val resource: Fixture[CryptoAlg[IO]] = ResourceSuiteLocalFixture("CryptoAlg[IO]", CryptoAlg.resource[IO])
+
+  override def munitFixtures: Seq[Fixture[_]] = List(resource)
+
+  test("CryptoAlg should support armoring a PGP value") {
+    val crypto = resource()
+    implicit val arbKeyPair: Arbitrary[Resource[IO, PGPKeyPair]] = arbWeakKeyPair[IO]
+
+    forAllF(genPgpBytes[IO]) { (bytesR: Resource[IO, Array[Byte]]) =>
+      val testResource =
+        for {
+          bytes <- bytesR
+          armored <- Stream.emits(bytes).through(crypto.armor).through(text.utf8.decode).compile.resource.string
+          expected <- Resource.eval {
+            for {
+              out <- IO(new ByteArrayOutputStream())
+              _ <- Resource.fromAutoCloseable(IO(new ArmoredOutputStream(out))).evalMap(arm => IO(arm.write(bytes))).use(_ => IO.unit)
+              s <- IO(new String(out.toByteArray))
+            } yield s
+          }
+        } yield (armored, expected)
+
+      testResource.use { case (armored, expected) => IO {
+        assertEquals(armored, expected)
+      }
+      }
+    }
+  }
+}

--- a/tests/src/test/scala/com/dwolla/security/crypto/CryptoAlgSpec.scala
+++ b/tests/src/test/scala/com/dwolla/security/crypto/CryptoAlgSpec.scala
@@ -4,19 +4,17 @@ import cats.data._
 import cats.effect._
 import cats.syntax.all._
 import com.dwolla.testutils._
+import com.eed3si9n.expecty.Expecty.{assert => Assert}
 import fs2._
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
-import org.bouncycastle.bcpg._
 import org.bouncycastle.openpgp._
 import org.scalacheck.Arbitrary._
 import org.scalacheck._
 import org.scalacheck.effect.PropF.{forAllF, forAllNoShrinkF}
 import org.scalacheck.util.Pretty
-import com.eed3si9n.expecty.Expecty.{assert => Assert}
 import org.typelevel.log4cats._
 import org.typelevel.log4cats.slf4j.Slf4jFactory
 
-import java.io.ByteArrayOutputStream
 import scala.concurrent.duration._
 
 class CryptoAlgSpec
@@ -27,12 +25,12 @@ class CryptoAlgSpec
 
   private implicit val loggerFactory: LoggerFactory[IO] = Slf4jFactory.create[IO]
 
-  private val resource: Fixture[CryptoAlg[IO]] = ResourceSuiteLocalFixture("CryptoAlg[IO]", CryptoAlg[IO])
+  private val resource: Fixture[CryptoAlg[IO]] = ResourceSuiteLocalFixture("CryptoAlg[IO]", CryptoAlg.resource[IO])
   override def munitFixtures: Seq[Fixture[_]] = List(resource)
 
   override protected def scalaCheckTestParameters: Test.Parameters =
     Test.Parameters.default
-      .withMinSuccessfulTests(2)
+      .withMinSuccessfulTests(10)
 
   override val munitTimeout: Duration = 2.minutes
 
@@ -134,30 +132,6 @@ class CryptoAlgSpec
     }
   }
 
-  test("CryptoAlg should support armoring a PGP value") {
-    val crypto = resource()
-    implicit val arbKeyPair: Arbitrary[Resource[IO, PGPKeyPair]] = arbWeakKeyPair[IO]
-
-    forAllF(genPgpBytes[IO]) { (bytesR: Resource[IO, Array[Byte]]) =>
-      val testResource =
-        for {
-          bytes <- bytesR
-          armored <- Stream.emits(bytes).through(crypto.armor()).through(text.utf8.decode).compile.resource.string
-          expected <- Resource.eval {
-            for {
-              out <- IO(new ByteArrayOutputStream())
-              _ <- Resource.fromAutoCloseable(IO(new ArmoredOutputStream(out))).evalMap(arm => IO(arm.write(bytes))).use(_ => IO.unit)
-              s <- IO(new String(out.toByteArray))
-            } yield s
-          }
-        } yield (armored, expected)
-
-      testResource.use { case (armored, expected) => IO {
-        assertEquals(armored, expected)
-      }}
-    }
-  }
-
   test("CryptoAlg should round trip the plaintext using a key ring collection") {
     val crypto = resource()
 
@@ -228,228 +202,6 @@ class CryptoAlgSpec
         assertEquals(roundTrip, materializedBytes)
       })
     }
-  }
-
-  /*
-   * Steps to generate cryptotext on macOS, having copied the test key to the clipboard:
-   *
-   *  > export GNUPGHOME="$(mktemp -d)/.gnupg"
-   *  > mkdir -m 0700 -p "${GNUPGHOME}"
-   *  > pbpaste | gpg --import
-   *  > echo "Hello World" | gpg --encrypt --armor --hidden-recipient "key 1 <key1@dwolla.com>"
-   */
-  test("CryptoAlg should decrypt cryptotext with a hidden recipient using secret key collection") {
-    val crypto = resource()
-
-    val message =
-      """-----BEGIN PGP MESSAGE-----
-        |
-        |hQGMAwAAAAAAAAAAAQv/QQ8RnRGF6jaPTUpuBoPollIBvPIzqokTGzuTaVD4bKsg
-        |GGt4ooPpcTkxn0MRLs3rNJfZjaULSkWtUxc4NsSbqmrl8g3smnwJWk/UIR097zlC
-        |s30/o3WlmSodAGbEuP5Y+mbAErwGbCs1e7cn1LqQO3BrSZ3m7djif9fiWRdb3AZ4
-        |YPX5dmmOZLZoNQO5zLNu3iolrTXyimQLcS7VoFQ+Nbj9hOS+vDzcg6Kycaky7U+M
-        |arfyyaqWan8hVygDthMT+n3Au0l7lBzN99aZmC13OP2fhuBBXvrGF+njFS+RkEOs
-        |LToMlpFVYWlEFSnYlIQjsxKBzMKThNudKM7r4Kc1yw88DQ9C/rWZxmMxTyLAA4C7
-        |QZKdO+zYfzSCYq3bO+YdN8vUGZPS63YN8Pp6qWvIXOZ3oecxmidqjGsItLpxJ0KK
-        |zJ0IWVsQj1Zc/2zSojw8edcMh86PFbQsC4aPpMK54KiU4YKXcUnaDeQ48BGv27Po
-        |Qx9PqZi+1ROo+anCVWrn0kcB/+g0TzSpG+nwMI4gxNTTAuybzEscK2ifkA76Df45
-        |cSypFoj4OIRtTZ8iSGhfgt0fCn1qUrEs7Vw+iNYSqpl9/ue3u1icCQ==
-        |=kHjl
-        |-----END PGP MESSAGE-----
-        |""".stripMargin
-
-    for {
-      key <- PGPKeyAlg[IO].readSecretKeyCollection(TestKey())
-      text <- Stream
-        .emit(message)
-        .through(text.utf8.encode)
-        .through(crypto.decrypt(key))
-        .through(text.utf8.decode)
-        .compile
-        .lastOrError
-    } yield {
-      assertEquals(text, "Hello World\n")
-    }
-  }
-
-  /*
-   * Steps to generate cryptotext on macOS, having copied the test key to the clipboard:
-   *
-   *  > export GNUPGHOME="$(mktemp -d)/.gnupg"
-   *  > mkdir -m 0700 -p "${GNUPGHOME}"
-   *  > pbpaste | gpg --import
-   *  > echo "Hello World" | gpg --encrypt --armor --recipient "key 1 <key1@dwolla.com>"
-   */
-  test("CryptoAlg should decrypt cryptotext with a known recipient using secret key collection") {
-    val crypto = resource()
-
-    val message =
-      """-----BEGIN PGP MESSAGE-----
-        |
-        |hQGMA1TkhEz+fGjhAQwAmJa5ZefcoKp0xp2AyPf1W/cPb/L7qwohnxiwjOmOZOWx
-        |APAbFWbqqMCUqoFqWIE3Uo1k2xfBe+gy3lZzEpaNcWqo5cNcFRajZCpC4Jh5AWKZ
-        |z3wTzlmKoO+JRi7PshuPbGeiYNRYiayfc2L9bQFB2zFx/99Q542oQmRo/dFtjpNQ
-        |rROUmGmhuZTFKFoCa8EQlglOu0tUH4pn79mA3POwiYKSO+nySOXlciOUzofauVKz
-        |mv0YzEapgmGUSMH7itNa3OWpYuip0EVeg4juoY1Qm0ae+AHV1mGcTn/k5vT4r55Z
-        |0yyzRhACb5lnS2OllNVcjV9LkQ8PdosEKGfLDHniF/OaAj7KF79N9CqwMAA1ng1J
-        |3oHj3oJcxPEtrccgkGErtQJvrC0UENQGDZS171DXmYKSyiP0W+GU26oeDo5L7vug
-        |61LcAL4fKkj6PWkLu/iFoWStnPdI2prqJ4fUGGmYyiTf8sL/HD1Zmj+wgbd4svUo
-        |Jlmzgr/sl2FC0avgYnFi0kcBGfqqvZ8D2QSIk+1xmOckKc3MBRYboDYHlaKYecit
-        |cWo+Lvh6NbHbJcfDjewdJe2A7FKm6YGZUVhOvZEC1Lf2fQ/A++ZGZg==
-        |=TVjb
-        |-----END PGP MESSAGE-----
-        |""".stripMargin
-
-    for {
-      key <- PGPKeyAlg[IO].readSecretKeyCollection(TestKey())
-      text <- Stream
-        .emit(message)
-        .through(text.utf8.encode)
-        .through(crypto.decrypt(key))
-        .through(text.utf8.decode)
-        .compile
-        .lastOrError
-    } yield {
-      assertEquals(text, "Hello World\n")
-    }
-  }
-
-  /*
-   * Steps to generate cryptotext on macOS, having copied the test key to the clipboard:
-   *
-   *  > export GNUPGHOME="$(mktemp -d)/.gnupg"
-   *  > mkdir -m 0700 -p "${GNUPGHOME}"
-   *  > pbpaste | gpg --import
-   *  > echo "Hello World" | gpg --encrypt --armor --hidden-recipient "key 1 <key1@dwolla.com>"
-   */
-  test("CryptoAlg should decrypt cryptotext with a hidden recipient using private key") {
-    val crypto = resource()
-
-    val message =
-      """-----BEGIN PGP MESSAGE-----
-        |
-        |hQGMAwAAAAAAAAAAAQv/QQ8RnRGF6jaPTUpuBoPollIBvPIzqokTGzuTaVD4bKsg
-        |GGt4ooPpcTkxn0MRLs3rNJfZjaULSkWtUxc4NsSbqmrl8g3smnwJWk/UIR097zlC
-        |s30/o3WlmSodAGbEuP5Y+mbAErwGbCs1e7cn1LqQO3BrSZ3m7djif9fiWRdb3AZ4
-        |YPX5dmmOZLZoNQO5zLNu3iolrTXyimQLcS7VoFQ+Nbj9hOS+vDzcg6Kycaky7U+M
-        |arfyyaqWan8hVygDthMT+n3Au0l7lBzN99aZmC13OP2fhuBBXvrGF+njFS+RkEOs
-        |LToMlpFVYWlEFSnYlIQjsxKBzMKThNudKM7r4Kc1yw88DQ9C/rWZxmMxTyLAA4C7
-        |QZKdO+zYfzSCYq3bO+YdN8vUGZPS63YN8Pp6qWvIXOZ3oecxmidqjGsItLpxJ0KK
-        |zJ0IWVsQj1Zc/2zSojw8edcMh86PFbQsC4aPpMK54KiU4YKXcUnaDeQ48BGv27Po
-        |Qx9PqZi+1ROo+anCVWrn0kcB/+g0TzSpG+nwMI4gxNTTAuybzEscK2ifkA76Df45
-        |cSypFoj4OIRtTZ8iSGhfgt0fCn1qUrEs7Vw+iNYSqpl9/ue3u1icCQ==
-        |=kHjl
-        |-----END PGP MESSAGE-----
-        |""".stripMargin
-
-    for {
-      key <- PGPKeyAlg[IO].readPrivateKey(TestKey.privateSubKey)
-      text <- Stream
-        .emit(message)
-        .through(text.utf8.encode)
-        .through(crypto.decrypt(key))
-        .through(text.utf8.decode)
-        .compile
-        .lastOrError
-    } yield {
-      assertEquals(text, "Hello World\n")
-    }
-  }
-
-  /*
-   * Steps to generate cryptotext on macOS, having copied the test key to the clipboard:
-   *
-   *  > export GNUPGHOME="$(mktemp -d)/.gnupg"
-   *  > mkdir -m 0700 -p "${GNUPGHOME}"
-   *  > pbpaste | gpg --import
-   *  > echo "Hello World" | gpg --encrypt --armor --recipient "key 1 <key1@dwolla.com>"
-   */
-  test("CryptoAlg should decrypt cryptotext with a known recipient using private key") {
-    val crypto = resource()
-
-    val message =
-      """-----BEGIN PGP MESSAGE-----
-        |
-        |hQGMA1TkhEz+fGjhAQwAmJa5ZefcoKp0xp2AyPf1W/cPb/L7qwohnxiwjOmOZOWx
-        |APAbFWbqqMCUqoFqWIE3Uo1k2xfBe+gy3lZzEpaNcWqo5cNcFRajZCpC4Jh5AWKZ
-        |z3wTzlmKoO+JRi7PshuPbGeiYNRYiayfc2L9bQFB2zFx/99Q542oQmRo/dFtjpNQ
-        |rROUmGmhuZTFKFoCa8EQlglOu0tUH4pn79mA3POwiYKSO+nySOXlciOUzofauVKz
-        |mv0YzEapgmGUSMH7itNa3OWpYuip0EVeg4juoY1Qm0ae+AHV1mGcTn/k5vT4r55Z
-        |0yyzRhACb5lnS2OllNVcjV9LkQ8PdosEKGfLDHniF/OaAj7KF79N9CqwMAA1ng1J
-        |3oHj3oJcxPEtrccgkGErtQJvrC0UENQGDZS171DXmYKSyiP0W+GU26oeDo5L7vug
-        |61LcAL4fKkj6PWkLu/iFoWStnPdI2prqJ4fUGGmYyiTf8sL/HD1Zmj+wgbd4svUo
-        |Jlmzgr/sl2FC0avgYnFi0kcBGfqqvZ8D2QSIk+1xmOckKc3MBRYboDYHlaKYecit
-        |cWo+Lvh6NbHbJcfDjewdJe2A7FKm6YGZUVhOvZEC1Lf2fQ/A++ZGZg==
-        |=TVjb
-        |-----END PGP MESSAGE-----
-        |""".stripMargin
-
-    for {
-      key <- PGPKeyAlg[IO].readPrivateKey(TestKey.privateSubKey)
-      text <- Stream
-        .emit(message)
-        .through(text.utf8.encode)
-        .through(crypto.decrypt(key))
-        .through(text.utf8.decode)
-        .compile
-        .lastOrError
-    } yield {
-      assertEquals(text, "Hello World\n")
-    }
-  }
-
-  /*
-   * Steps to generate cryptotext on macOS, having copied the test key to the clipboard:
-   *
-   *  > export GNUPGHOME="$(mktemp -d)/.gnupg"
-   *  > mkdir -m 0700 -p "${GNUPGHOME}"
-   *  > pbpaste | gpg --import
-   *  > # pause here, copy the secondary key into the clipboard
-   *  > pbpaste | gpg --import
-   *  > echo "Hello World" | gpg --encrypt --armor --recipient "key 2 <key2@dwolla.com> --recipient "key 1 <key1@dwolla.com>"
-   */
-  test("CryptoAlg should decrypt cryptotext with multiple recipients using secret key collection") {
-    val crypto = resource()
-    
-    val message = 
-      """-----BEGIN PGP MESSAGE-----
-        |
-        |hQGMAzY3u+LAhf1LAQv/Z38VFkyLZglKYLfr7uLoX0kzewFKO2fOMLZfIeTkXteI
-        |pTmpjra93bBiDX5osdL+NCf7kw20Bh+gX8aN2bE3N9DXccNBDidt21GdXCrBN293
-        |b5hB3ysDPbHsqr0EVrDdFZmaZkuvqmO5mzED1eMAMSDZnj9MGuu1jxGphlJ56O6K
-        |eP1T15aJZCteLpnOaxlxMXf8Vyd6oBRumHDhaNocOQcVzDTHv/yXhxbcumkbX74w
-        |vJjOrQekrpqZdrpuvL3/t4OLNSmrQhgiCpRrvIxfFvwXdPlrpMX15K1NxsvwSnzp
-        |2a8fX2TSQtv6XGod0XbLmga4MtelfbLFFQVIa+dYpZpmaEQQf+T2730nf7mh54Zz
-        |xd9PwCxNnLax0HtFdNHZKJB6StgnuXyifNuNoJYwu0nPniIFRm34e33OWV++31Jg
-        |E5NVRgfIYMN1Jb4iVCvaA8UYLi2A/FmmSyCC4meWyESEBq13vnlAuOclQ5P/nA5V
-        |b/lK/d3TTLERhWRpqLoZhQGMA1TkhEz+fGjhAQwAsvrx4a58A/KRgV9nlZAVoJKB
-        |9CbuqT/iEWL8yEfaD7tGqWnH52SYZhy6Bp9abhMQ74wfGxNx/ou4/xVJLNoMAx6w
-        |D/rTC1hfJx2T+aUgBFHgjZk6frCILXcJIFxNUs6FZzws+3Wn/mJdrLLhiy/dB9l+
-        |B/s4zQgeDue/RsfHw3vAljP4M4O6Jkr/v9E04sTCNmmZ+js99G7huAsfTEmLaWvY
-        |FX3ST/zjvO9MmjHYCKDvGZeOrxZ+U4Ke1glHqoD11U2KchLTFzS/+CmE/9AbV8N/
-        |jnC3KKIfdzf5baWDrqO+icu7A2fcFCMu6AmyzJd/zuS0IMQMNZXiyR1DEUJg6qnd
-        |yT9g2GLlOJDETSVvE1hfyvrLDSBHtFA1uoxkTg7J9k8SfH/44atkigQoDLS6Tkoh
-        |Wq1jS+HCdNpgg7lhtyuC3nYhg6lPSD46SbOj+umB0C161/XiGUvFvu5Iw6AEni2N
-        |ssZLujYlZQdl0zZiMK9tf+bNEjJjZ4BErtqkCY8s0kcBYiQtZb2Py6pb8sqL75sd
-        |tZKE+J7duo1GdvI5VqgHRakgeFJtOyrbHtTtl/SLRfhewRyYPcbiBVod3GunRE4p
-        |ijuxbxOi9A==
-        |=MMZb
-        |-----END PGP MESSAGE-----
-        |""".stripMargin
-
-    for {
-      key <- PGPKeyAlg[IO].readSecretKeyCollection(TestKey())
-      text <- Stream
-        .emit(message)
-        .through(text.utf8.encode)
-        .through(crypto.decrypt(key))
-        .through(text.utf8.decode)
-        .compile
-        .lastOrError
-    } yield {
-      assertEquals(text, "Hello World\n")
-    }
-    
   }
 
   private implicit def prettyArrayChar: Array[Char] => Pretty = arr => Pretty { _ =>

--- a/tests/src/test/scala/com/dwolla/security/crypto/CryptoAlgSpec.scala
+++ b/tests/src/test/scala/com/dwolla/security/crypto/CryptoAlgSpec.scala
@@ -108,7 +108,7 @@ class CryptoAlgSpec
         encryptionChunkSize <- arbitrary[ChunkSize]
         // since the cryptotext is compressed, we need to generate at least 10x the chunk size to
         // be fairly confident that there will be at least one full-sized chunk
-        bytes <- genNBytesBetween(encryptionChunkSize.value * 10, 1 << 16)
+        bytes <- genNBytesBetween(encryptionChunkSize.unrefined * 10, 1 << 16)
       } yield Inputs(keyPairR, encryptionChunkSize, bytes)
 
     forAllNoShrinkF(genChunkSizeTestInputs) { case Inputs(keyPairR, encryptionChunkSize, bytes) =>
@@ -126,7 +126,7 @@ class CryptoAlgSpec
         } yield chunkSizes
 
       testResource.use(chunkSizes => IO {
-        Assert(chunkSizes.contains(encryptionChunkSize.value))
+        Assert(chunkSizes.contains(encryptionChunkSize.unrefined))
         Assert(Set(1, 2) contains chunkSizes.size)
       })
     }

--- a/tests/src/test/scala/com/dwolla/security/crypto/DecryptSpec.scala
+++ b/tests/src/test/scala/com/dwolla/security/crypto/DecryptSpec.scala
@@ -1,0 +1,239 @@
+package com.dwolla.security.crypto
+
+import cats.effect._
+import fs2._
+import munit.CatsEffectSuite
+import org.typelevel.log4cats._
+import org.typelevel.log4cats.slf4j.Slf4jFactory
+
+class DecryptSpec
+  extends CatsEffectSuite {
+
+  private implicit val loggerFactory: LoggerFactory[IO] = Slf4jFactory.create[IO]
+
+  private val resource: Fixture[CryptoAlg[IO]] = ResourceSuiteLocalFixture("CryptoAlg[IO]", CryptoAlg.resource[IO])
+
+  override def munitFixtures: Seq[Fixture[_]] = List(resource)
+
+  /*
+   * Steps to generate cryptotext on macOS, having copied the test key to the clipboard:
+   *
+   *  > export GNUPGHOME="$(mktemp -d)/.gnupg"
+   *  > mkdir -m 0700 -p "${GNUPGHOME}"
+   *  > pbpaste | gpg --import
+   *  > echo "Hello World" | gpg --encrypt --armor --hidden-recipient "key 1 <key1@dwolla.com>"
+   */
+  test("CryptoAlg should decrypt cryptotext with a hidden recipient using secret key collection") {
+    val crypto = resource()
+
+    val message =
+      """-----BEGIN PGP MESSAGE-----
+        |
+        |hQGMAwAAAAAAAAAAAQv/QQ8RnRGF6jaPTUpuBoPollIBvPIzqokTGzuTaVD4bKsg
+        |GGt4ooPpcTkxn0MRLs3rNJfZjaULSkWtUxc4NsSbqmrl8g3smnwJWk/UIR097zlC
+        |s30/o3WlmSodAGbEuP5Y+mbAErwGbCs1e7cn1LqQO3BrSZ3m7djif9fiWRdb3AZ4
+        |YPX5dmmOZLZoNQO5zLNu3iolrTXyimQLcS7VoFQ+Nbj9hOS+vDzcg6Kycaky7U+M
+        |arfyyaqWan8hVygDthMT+n3Au0l7lBzN99aZmC13OP2fhuBBXvrGF+njFS+RkEOs
+        |LToMlpFVYWlEFSnYlIQjsxKBzMKThNudKM7r4Kc1yw88DQ9C/rWZxmMxTyLAA4C7
+        |QZKdO+zYfzSCYq3bO+YdN8vUGZPS63YN8Pp6qWvIXOZ3oecxmidqjGsItLpxJ0KK
+        |zJ0IWVsQj1Zc/2zSojw8edcMh86PFbQsC4aPpMK54KiU4YKXcUnaDeQ48BGv27Po
+        |Qx9PqZi+1ROo+anCVWrn0kcB/+g0TzSpG+nwMI4gxNTTAuybzEscK2ifkA76Df45
+        |cSypFoj4OIRtTZ8iSGhfgt0fCn1qUrEs7Vw+iNYSqpl9/ue3u1icCQ==
+        |=kHjl
+        |-----END PGP MESSAGE-----
+        |""".stripMargin
+
+    for {
+      key <- PGPKeyAlg[IO].readSecretKeyCollection(TestKey())
+      text <- Stream
+        .emit(message)
+        .through(text.utf8.encode)
+        .through(crypto.decrypt(key))
+        .through(text.utf8.decode)
+        .compile
+        .lastOrError
+    } yield {
+      assertEquals(text, "Hello World\n")
+    }
+  }
+
+  /*
+   * Steps to generate cryptotext on macOS, having copied the test key to the clipboard:
+   *
+   *  > export GNUPGHOME="$(mktemp -d)/.gnupg"
+   *  > mkdir -m 0700 -p "${GNUPGHOME}"
+   *  > pbpaste | gpg --import
+   *  > echo "Hello World" | gpg --encrypt --armor --recipient "key 1 <key1@dwolla.com>"
+   */
+  test("CryptoAlg should decrypt cryptotext with a known recipient using secret key collection") {
+    val crypto = resource()
+
+    val message =
+      """-----BEGIN PGP MESSAGE-----
+        |
+        |hQGMA1TkhEz+fGjhAQwAmJa5ZefcoKp0xp2AyPf1W/cPb/L7qwohnxiwjOmOZOWx
+        |APAbFWbqqMCUqoFqWIE3Uo1k2xfBe+gy3lZzEpaNcWqo5cNcFRajZCpC4Jh5AWKZ
+        |z3wTzlmKoO+JRi7PshuPbGeiYNRYiayfc2L9bQFB2zFx/99Q542oQmRo/dFtjpNQ
+        |rROUmGmhuZTFKFoCa8EQlglOu0tUH4pn79mA3POwiYKSO+nySOXlciOUzofauVKz
+        |mv0YzEapgmGUSMH7itNa3OWpYuip0EVeg4juoY1Qm0ae+AHV1mGcTn/k5vT4r55Z
+        |0yyzRhACb5lnS2OllNVcjV9LkQ8PdosEKGfLDHniF/OaAj7KF79N9CqwMAA1ng1J
+        |3oHj3oJcxPEtrccgkGErtQJvrC0UENQGDZS171DXmYKSyiP0W+GU26oeDo5L7vug
+        |61LcAL4fKkj6PWkLu/iFoWStnPdI2prqJ4fUGGmYyiTf8sL/HD1Zmj+wgbd4svUo
+        |Jlmzgr/sl2FC0avgYnFi0kcBGfqqvZ8D2QSIk+1xmOckKc3MBRYboDYHlaKYecit
+        |cWo+Lvh6NbHbJcfDjewdJe2A7FKm6YGZUVhOvZEC1Lf2fQ/A++ZGZg==
+        |=TVjb
+        |-----END PGP MESSAGE-----
+        |""".stripMargin
+
+    for {
+      key <- PGPKeyAlg[IO].readSecretKeyCollection(TestKey())
+      text <- Stream
+        .emit(message)
+        .through(text.utf8.encode)
+        .through(crypto.decrypt(key))
+        .through(text.utf8.decode)
+        .compile
+        .lastOrError
+    } yield {
+      assertEquals(text, "Hello World\n")
+    }
+  }
+
+  /*
+   * Steps to generate cryptotext on macOS, having copied the test key to the clipboard:
+   *
+   *  > export GNUPGHOME="$(mktemp -d)/.gnupg"
+   *  > mkdir -m 0700 -p "${GNUPGHOME}"
+   *  > pbpaste | gpg --import
+   *  > echo "Hello World" | gpg --encrypt --armor --hidden-recipient "key 1 <key1@dwolla.com>"
+   */
+  test("CryptoAlg should decrypt cryptotext with a hidden recipient using private key") {
+    val crypto = resource()
+
+    val message =
+      """-----BEGIN PGP MESSAGE-----
+        |
+        |hQGMAwAAAAAAAAAAAQv/QQ8RnRGF6jaPTUpuBoPollIBvPIzqokTGzuTaVD4bKsg
+        |GGt4ooPpcTkxn0MRLs3rNJfZjaULSkWtUxc4NsSbqmrl8g3smnwJWk/UIR097zlC
+        |s30/o3WlmSodAGbEuP5Y+mbAErwGbCs1e7cn1LqQO3BrSZ3m7djif9fiWRdb3AZ4
+        |YPX5dmmOZLZoNQO5zLNu3iolrTXyimQLcS7VoFQ+Nbj9hOS+vDzcg6Kycaky7U+M
+        |arfyyaqWan8hVygDthMT+n3Au0l7lBzN99aZmC13OP2fhuBBXvrGF+njFS+RkEOs
+        |LToMlpFVYWlEFSnYlIQjsxKBzMKThNudKM7r4Kc1yw88DQ9C/rWZxmMxTyLAA4C7
+        |QZKdO+zYfzSCYq3bO+YdN8vUGZPS63YN8Pp6qWvIXOZ3oecxmidqjGsItLpxJ0KK
+        |zJ0IWVsQj1Zc/2zSojw8edcMh86PFbQsC4aPpMK54KiU4YKXcUnaDeQ48BGv27Po
+        |Qx9PqZi+1ROo+anCVWrn0kcB/+g0TzSpG+nwMI4gxNTTAuybzEscK2ifkA76Df45
+        |cSypFoj4OIRtTZ8iSGhfgt0fCn1qUrEs7Vw+iNYSqpl9/ue3u1icCQ==
+        |=kHjl
+        |-----END PGP MESSAGE-----
+        |""".stripMargin
+
+    for {
+      key <- PGPKeyAlg[IO].readPrivateKey(TestKey.privateSubKey)
+      text <- Stream
+        .emit(message)
+        .through(text.utf8.encode)
+        .through(crypto.decrypt(key))
+        .through(text.utf8.decode)
+        .compile
+        .lastOrError
+    } yield {
+      assertEquals(text, "Hello World\n")
+    }
+  }
+
+  /*
+   * Steps to generate cryptotext on macOS, having copied the test key to the clipboard:
+   *
+   *  > export GNUPGHOME="$(mktemp -d)/.gnupg"
+   *  > mkdir -m 0700 -p "${GNUPGHOME}"
+   *  > pbpaste | gpg --import
+   *  > echo "Hello World" | gpg --encrypt --armor --recipient "key 1 <key1@dwolla.com>"
+   */
+  test("CryptoAlg should decrypt cryptotext with a known recipient using private key") {
+    val crypto = resource()
+
+    val message =
+      """-----BEGIN PGP MESSAGE-----
+        |
+        |hQGMA1TkhEz+fGjhAQwAmJa5ZefcoKp0xp2AyPf1W/cPb/L7qwohnxiwjOmOZOWx
+        |APAbFWbqqMCUqoFqWIE3Uo1k2xfBe+gy3lZzEpaNcWqo5cNcFRajZCpC4Jh5AWKZ
+        |z3wTzlmKoO+JRi7PshuPbGeiYNRYiayfc2L9bQFB2zFx/99Q542oQmRo/dFtjpNQ
+        |rROUmGmhuZTFKFoCa8EQlglOu0tUH4pn79mA3POwiYKSO+nySOXlciOUzofauVKz
+        |mv0YzEapgmGUSMH7itNa3OWpYuip0EVeg4juoY1Qm0ae+AHV1mGcTn/k5vT4r55Z
+        |0yyzRhACb5lnS2OllNVcjV9LkQ8PdosEKGfLDHniF/OaAj7KF79N9CqwMAA1ng1J
+        |3oHj3oJcxPEtrccgkGErtQJvrC0UENQGDZS171DXmYKSyiP0W+GU26oeDo5L7vug
+        |61LcAL4fKkj6PWkLu/iFoWStnPdI2prqJ4fUGGmYyiTf8sL/HD1Zmj+wgbd4svUo
+        |Jlmzgr/sl2FC0avgYnFi0kcBGfqqvZ8D2QSIk+1xmOckKc3MBRYboDYHlaKYecit
+        |cWo+Lvh6NbHbJcfDjewdJe2A7FKm6YGZUVhOvZEC1Lf2fQ/A++ZGZg==
+        |=TVjb
+        |-----END PGP MESSAGE-----
+        |""".stripMargin
+
+    for {
+      key <- PGPKeyAlg[IO].readPrivateKey(TestKey.privateSubKey)
+      text <- Stream
+        .emit(message)
+        .through(text.utf8.encode)
+        .through(crypto.decrypt(key))
+        .through(text.utf8.decode)
+        .compile
+        .lastOrError
+    } yield {
+      assertEquals(text, "Hello World\n")
+    }
+  }
+
+  /*
+   * Steps to generate cryptotext on macOS, having copied the test key to the clipboard:
+   *
+   *  > export GNUPGHOME="$(mktemp -d)/.gnupg"
+   *  > mkdir -m 0700 -p "${GNUPGHOME}"
+   *  > pbpaste | gpg --import
+   *  > # pause here, copy the secondary key into the clipboard
+   *  > pbpaste | gpg --import
+   *  > echo "Hello World" | gpg --encrypt --armor --recipient "key 2 <key2@dwolla.com> --recipient "key 1 <key1@dwolla.com>"
+   */
+  test("CryptoAlg should decrypt cryptotext with multiple recipients using secret key collection") {
+    val crypto = resource()
+
+    val message =
+      """-----BEGIN PGP MESSAGE-----
+        |
+        |hQGMAzY3u+LAhf1LAQv/Z38VFkyLZglKYLfr7uLoX0kzewFKO2fOMLZfIeTkXteI
+        |pTmpjra93bBiDX5osdL+NCf7kw20Bh+gX8aN2bE3N9DXccNBDidt21GdXCrBN293
+        |b5hB3ysDPbHsqr0EVrDdFZmaZkuvqmO5mzED1eMAMSDZnj9MGuu1jxGphlJ56O6K
+        |eP1T15aJZCteLpnOaxlxMXf8Vyd6oBRumHDhaNocOQcVzDTHv/yXhxbcumkbX74w
+        |vJjOrQekrpqZdrpuvL3/t4OLNSmrQhgiCpRrvIxfFvwXdPlrpMX15K1NxsvwSnzp
+        |2a8fX2TSQtv6XGod0XbLmga4MtelfbLFFQVIa+dYpZpmaEQQf+T2730nf7mh54Zz
+        |xd9PwCxNnLax0HtFdNHZKJB6StgnuXyifNuNoJYwu0nPniIFRm34e33OWV++31Jg
+        |E5NVRgfIYMN1Jb4iVCvaA8UYLi2A/FmmSyCC4meWyESEBq13vnlAuOclQ5P/nA5V
+        |b/lK/d3TTLERhWRpqLoZhQGMA1TkhEz+fGjhAQwAsvrx4a58A/KRgV9nlZAVoJKB
+        |9CbuqT/iEWL8yEfaD7tGqWnH52SYZhy6Bp9abhMQ74wfGxNx/ou4/xVJLNoMAx6w
+        |D/rTC1hfJx2T+aUgBFHgjZk6frCILXcJIFxNUs6FZzws+3Wn/mJdrLLhiy/dB9l+
+        |B/s4zQgeDue/RsfHw3vAljP4M4O6Jkr/v9E04sTCNmmZ+js99G7huAsfTEmLaWvY
+        |FX3ST/zjvO9MmjHYCKDvGZeOrxZ+U4Ke1glHqoD11U2KchLTFzS/+CmE/9AbV8N/
+        |jnC3KKIfdzf5baWDrqO+icu7A2fcFCMu6AmyzJd/zuS0IMQMNZXiyR1DEUJg6qnd
+        |yT9g2GLlOJDETSVvE1hfyvrLDSBHtFA1uoxkTg7J9k8SfH/44atkigQoDLS6Tkoh
+        |Wq1jS+HCdNpgg7lhtyuC3nYhg6lPSD46SbOj+umB0C161/XiGUvFvu5Iw6AEni2N
+        |ssZLujYlZQdl0zZiMK9tf+bNEjJjZ4BErtqkCY8s0kcBYiQtZb2Py6pb8sqL75sd
+        |tZKE+J7duo1GdvI5VqgHRakgeFJtOyrbHtTtl/SLRfhewRyYPcbiBVod3GunRE4p
+        |ijuxbxOi9A==
+        |=MMZb
+        |-----END PGP MESSAGE-----
+        |""".stripMargin
+
+    for {
+      key <- PGPKeyAlg[IO].readSecretKeyCollection(TestKey())
+      text <- Stream
+        .emit(message)
+        .through(text.utf8.encode)
+        .through(crypto.decrypt(key))
+        .through(text.utf8.decode)
+        .compile
+        .lastOrError
+    } yield {
+      assertEquals(text, "Hello World\n")
+    }
+
+  }
+}

--- a/tests/src/test/scala/com/dwolla/security/crypto/PGPKeyAlgSpec.scala
+++ b/tests/src/test/scala/com/dwolla/security/crypto/PGPKeyAlgSpec.scala
@@ -85,9 +85,9 @@ class PGPKeyAlgSpec
       val testResource = keyR.evalMap { key =>
         val armored: IO[String] =
           (for {
-            crypto <- Stream.resource(CryptoAlg[IO])
+            crypto <- Stream.resource(CryptoAlg.resource[IO])
             armored <- Stream.emits(key.getEncoded)
-              .through(crypto.armor())
+              .through(crypto.armor)
               .through(text.utf8.decode)
           } yield armored).compile.resource.string.use(s => s.pure[IO])
 
@@ -112,7 +112,7 @@ class PGPKeyAlgSpec
       val testResource = kp.evalMap { keyPair =>
         val armoredKey =
           (for {
-            crypto <- CryptoAlg[IO]
+            crypto <- CryptoAlg.resource[IO]
             secretKey <- Resource.eval(IO.blocking {
               val sha1Calc: PGPDigestCalculator = new JcaPGPDigestCalculatorProviderBuilder().build().get(HashAlgorithmTags.SHA1)
               new PGPSecretKey(PGPSignature.DEFAULT_CERTIFICATION, keyPair, "identity", sha1Calc, null, null, new JcaPGPContentSignerBuilder(keyPair.getPublicKey.getAlgorithm, HashAlgorithmTags.SHA256), new JcePBESecretKeyEncryptorBuilder(SymmetricKeyAlgorithmTags.AES_256, sha1Calc).setProvider("BC").build(passphrase))
@@ -121,7 +121,7 @@ class PGPKeyAlgSpec
               readOutputStream(4096) { os =>
                 IO.blocking(secretKey.encode(os))
               }
-                .through(crypto.armor())
+                .through(crypto.armor)
                 .through(text.utf8.decode)
                 .compile
                 .resource
@@ -146,7 +146,7 @@ class PGPKeyAlgSpec
       val testResource = kp.evalMap { keyPair =>
         val armoredKey =
           (for {
-            crypto <- CryptoAlg[IO]
+            crypto <- CryptoAlg.resource[IO]
             secretKey <- Resource.eval(IO.blocking {
               val sha1Calc: PGPDigestCalculator = new JcaPGPDigestCalculatorProviderBuilder().build().get(HashAlgorithmTags.SHA1)
               new PGPSecretKey(PGPSignature.DEFAULT_CERTIFICATION, keyPair, "identity", sha1Calc, null, null, new JcaPGPContentSignerBuilder(keyPair.getPublicKey.getAlgorithm, HashAlgorithmTags.SHA256), new JcePBESecretKeyEncryptorBuilder(SymmetricKeyAlgorithmTags.AES_256, sha1Calc).setProvider("BC").build(passphrase))
@@ -155,7 +155,7 @@ class PGPKeyAlgSpec
               readOutputStream(chunkSize.value) { os =>
                 IO.blocking(secretKey.encode(os))
               }
-                .through(crypto.armor())
+                .through(crypto.armor)
                 .through(text.utf8.decode)
                 .compile
                 .resource

--- a/tests/src/test/scala/com/dwolla/security/crypto/PGPKeyAlgSpec.scala
+++ b/tests/src/test/scala/com/dwolla/security/crypto/PGPKeyAlgSpec.scala
@@ -14,9 +14,9 @@ import org.bouncycastle.openpgp.operator.jcajce.{JcaPGPContentSignerBuilder, Jca
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.effect.PropF.forAllF
-import org.typelevel.log4cats._
-import org.typelevel.log4cats.noop.NoOpLogger
 import com.eed3si9n.expecty.Expecty.{assert => Assert}
+import org.typelevel.log4cats.LoggerFactory
+import org.typelevel.log4cats.slf4j.Slf4jFactory
 
 import scala.jdk.CollectionConverters._
 
@@ -25,10 +25,8 @@ class PGPKeyAlgSpec
     with ScalaCheckEffectSuite
     with PgpArbitraries
     with CryptoArbitraries {
-  private implicit val L: LoggerFactory[IO] = new LoggerFactory[IO] {
-    override def getLoggerFromName(name: String): SelfAwareStructuredLogger[IO] = NoOpLogger[IO]
-    override def fromName(name: String): IO[SelfAwareStructuredLogger[IO]] = NoOpLogger[IO].pure[IO]
-  }
+
+  private implicit val loggerFactory: LoggerFactory[IO] = Slf4jFactory.create[IO]
 
   test("PGPKeyAlg should load a PGPPublicKey from armored public key") {
     val key =

--- a/tests/src/test/scala/com/dwolla/security/crypto/PGPKeyAlgSpec.scala
+++ b/tests/src/test/scala/com/dwolla/security/crypto/PGPKeyAlgSpec.scala
@@ -152,7 +152,7 @@ class PGPKeyAlgSpec
               new PGPSecretKey(PGPSignature.DEFAULT_CERTIFICATION, keyPair, "identity", sha1Calc, null, null, new JcaPGPContentSignerBuilder(keyPair.getPublicKey.getAlgorithm, HashAlgorithmTags.SHA256), new JcePBESecretKeyEncryptorBuilder(SymmetricKeyAlgorithmTags.AES_256, sha1Calc).setProvider("BC").build(passphrase))
             })
             armoredKey <-
-              readOutputStream(chunkSize.value) { os =>
+              readOutputStream(chunkSize.unrefined) { os =>
                 IO.blocking(secretKey.encode(os))
               }
                 .through(crypto.armor)


### PR DESCRIPTION
In order to add support for Scala 3, we need to update to Refined 0.11 and swap out Shapeless tagged types with a Scala-3 compatible library like Monix Newtypes. Since that all requires making changes to the ABI, it's a good opportunity to remove a lot of bincompat cruft that had built up, and also make the core algebras available independently. This omnibus PR does all of that.

I'm working on Scalafixes for the source-breaking changes, so hopefully we can have those ready for Scala Steward to run before this is released as `v0.5.0`.