### PR TITLE
Allow for publishing snapshots from the series/0.5 branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,15 +57,15 @@ jobs:
       - run: sbt '++ ${{ matrix.scala }}' test mimaReportBinaryIssues doc
 
       - name: Make target directories
-        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
+        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/series/0.5')
         run: mkdir -p testkit/target testkit/.bcpg-1.75/target core/.bcpg-1.74/target core/target testkit/.bcpg-1.72.1/target testkit/.bcpg-1.72/target core/.bcpg-1.72.2/target core/.bcpg-1.73/target core/.bcpg-1.76/target core/.bcpg-1.71.1/target testkit/.bcpg-1.73/target core/.bcpg-1.72/target testkit/.bcpg-1.74/target testkit/.bcpg-1.71/target testkit/.bcpg-1.76/target core/.bcpg-1.75/target testkit/.bcpg-1.72.2/target core/.bcpg-1.71/target core/.bcpg-1.72.1/target testkit/.bcpg-1.71.1/target project/target
 
       - name: Compress target directories
-        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
+        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/series/0.5')
         run: tar cf targets.tar testkit/target testkit/.bcpg-1.75/target core/.bcpg-1.74/target core/target testkit/.bcpg-1.72.1/target testkit/.bcpg-1.72/target core/.bcpg-1.72.2/target core/.bcpg-1.73/target core/.bcpg-1.76/target core/.bcpg-1.71.1/target testkit/.bcpg-1.73/target core/.bcpg-1.72/target testkit/.bcpg-1.74/target testkit/.bcpg-1.71/target testkit/.bcpg-1.76/target core/.bcpg-1.75/target testkit/.bcpg-1.72.2/target core/.bcpg-1.71/target core/.bcpg-1.72.1/target testkit/.bcpg-1.71.1/target project/target
 
       - name: Upload target directories
-        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
+        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/series/0.5')
         uses: actions/upload-artifact@v3
         with:
           name: target-${{ matrix.os }}-${{ matrix.java }}-${{ matrix.scala }}
@@ -74,7 +74,7 @@ jobs:
   publish:
     name: Publish Artifacts
     needs: [build]
-    if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
+    if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/series/0.5')
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ ThisBuild / scalaVersion := V.Scalas.head
 ThisBuild / crossScalaVersions := V.Scalas
 ThisBuild / organization := "com.dwolla"
 ThisBuild / homepage := Option(url("https://github.com/Dwolla/fs2-pgp"))
-ThisBuild / licenses += ("MIT", url("http://opensource.org/licenses/MIT"))
+ThisBuild / licenses += ("MIT", url("https://opensource.org/licenses/MIT"))
 ThisBuild / startYear := Option(2020)
 ThisBuild / developers := List(
   Developer(
@@ -22,7 +22,7 @@ ThisBuild / githubWorkflowBuild := Seq(WorkflowStep.Sbt(List("test", "mimaReport
 ThisBuild / tlJdkRelease := Option(8)
 ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("17"))
 ThisBuild / githubWorkflowScalaVersions := Seq("2.13", "2.12")
-ThisBuild / tlCiReleaseBranches := Seq("main")
+ThisBuild / tlCiReleaseBranches := Seq("main", "series/0.5")
 ThisBuild / tlBaseVersion := "0.4"
 ThisBuild / tlSonatypeUseLegacyHost := true
 ThisBuild / mergifyStewardConfig ~= {


### PR DESCRIPTION
My thought is that we'll keep `series/0.5` around while we're developing on it, and then when it's ready to be released, we'll merge it into `main` and drop it as a separate long-lived branch.