### PR TITLE
Further enhance 0.5 migration scalafix

### DIFF
--- a/scalafix/input/src/main/scala/example/SeveralDifferentUses.scala
+++ b/scalafix/input/src/main/scala/example/SeveralDifferentUses.scala
@@ -4,6 +4,7 @@ rule = com.dwolla.security.crypto.V04to05
 */
 import cats.effect.*
 import com.dwolla.security.crypto.*
+import eu.timepit.refined.auto.*
 import org.bouncycastle.openpgp.PGPPublicKey
 import org.typelevel.log4cats.LoggerFactory
 
@@ -16,13 +17,19 @@ object SeveralDifferentUses {
 
     // all arguments set
     alg.encrypt(key, chunkSize, Option("filename"), Encryption.Aes256, Compression.Bzip2, PgpLiteralDataPacketFormat.Utf8)
+    alg.encrypt(key, tagChunkSize(42), Option("filename"), Encryption.Aes256, Compression.Bzip2, PgpLiteralDataPacketFormat.Utf8)
 
     // all arguments set with named parameters
     alg.encrypt(key = key, chunkSize = chunkSize, fileName = Option("filename"), encryption = Encryption.Aes256, compression = Compression.Bzip2, packetFormat = PgpLiteralDataPacketFormat.Utf8)
+    alg.encrypt(key = key, chunkSize = {
+      tagChunkSize(42)
+    }, fileName = Option("filename"), encryption = Encryption.Aes256, compression = Compression.Bzip2, packetFormat = PgpLiteralDataPacketFormat.Utf8)
     alg.encrypt(key, chunkSize = chunkSize, fileName = Option("filename"), encryption = Encryption.Aes256, compression = Compression.Bzip2, packetFormat = PgpLiteralDataPacketFormat.Utf8)
 
     // random assortments
-    alg.encrypt(key, chunkSize, Option("filename"))
+    alg.encrypt(key, {
+      tagChunkSize(42)
+    }, Option("filename"))
     alg.encrypt(key, fileName = Option("filename"), chunkSize = chunkSize)
     alg.encrypt(key = key, encryption = Encryption.Aes256, packetFormat = PgpLiteralDataPacketFormat.Utf8)
     alg.encrypt(key, fileName = Option("filename"), compression = Compression.Bzip2)

--- a/scalafix/input/src/main/scala/example/SeveralDifferentUses.scala
+++ b/scalafix/input/src/main/scala/example/SeveralDifferentUses.scala
@@ -1,0 +1,32 @@
+package example
+/*
+rule = com.dwolla.security.crypto.V04to05
+*/
+import cats.effect.*
+import com.dwolla.security.crypto.*
+import org.bouncycastle.openpgp.PGPPublicKey
+import org.typelevel.log4cats.LoggerFactory
+
+object SeveralDifferentUses {
+  private def key: PGPPublicKey = ???
+  private def chunkSize: ChunkSize = ???
+  private implicit def loggerFactory: LoggerFactory[IO] = ???
+
+  CryptoAlg[IO].evalMap { alg =>
+
+    // all arguments set
+    alg.encrypt(key, chunkSize, Option("filename"), Encryption.Aes256, Compression.Bzip2, PgpLiteralDataPacketFormat.Utf8)
+
+    // all arguments set with named parameters
+    alg.encrypt(key = key, chunkSize = chunkSize, fileName = Option("filename"), encryption = Encryption.Aes256, compression = Compression.Bzip2, packetFormat = PgpLiteralDataPacketFormat.Utf8)
+    alg.encrypt(key, chunkSize = chunkSize, fileName = Option("filename"), encryption = Encryption.Aes256, compression = Compression.Bzip2, packetFormat = PgpLiteralDataPacketFormat.Utf8)
+
+    // random assortments
+    alg.encrypt(key, chunkSize, Option("filename"))
+    alg.encrypt(key, fileName = Option("filename"), chunkSize = chunkSize)
+    alg.encrypt(key = key, encryption = Encryption.Aes256, packetFormat = PgpLiteralDataPacketFormat.Utf8)
+    alg.encrypt(key, fileName = Option("filename"), compression = Compression.Bzip2)
+
+    ???
+  }
+}

--- a/scalafix/input/src/main/scala/example/UsesCryptoAlg.scala
+++ b/scalafix/input/src/main/scala/example/UsesCryptoAlg.scala
@@ -1,0 +1,33 @@
+package example
+/*
+rule = com.dwolla.security.crypto.V04to05
+*/
+import cats.effect.*
+import com.dwolla.security.crypto.*
+import eu.timepit.refined.types.all.PosInt
+import fs2.*
+import org.bouncycastle.openpgp.PGPPublicKey
+import org.typelevel.log4cats.LoggerFactory
+
+object UsesCryptoAlg extends ResourceApp.Simple {
+  private def key: PGPPublicKey = ???
+  private def untaggedChunkSize: PosInt = ???
+  private implicit def loggerFactory: LoggerFactory[IO] = ???
+
+  override def run: Resource[IO, Unit] =
+    CryptoAlg[IO].evalMap { alg =>
+      Stream
+        .empty
+        .through(alg.encrypt(
+          key,
+          tagChunkSize(untaggedChunkSize),
+          Option("filename"),
+          Encryption.Aes256,
+          Compression.Bzip2,
+          PgpLiteralDataPacketFormat.Utf8,
+        ))
+        .through(alg.armor())
+        .compile
+        .drain
+    }
+}

--- a/scalafix/input/src/main/scala/fix/Fs2Pgp.scala
+++ b/scalafix/input/src/main/scala/fix/Fs2Pgp.scala
@@ -10,6 +10,7 @@ import fs2._
 import fs2.text._
 import com.dwolla.security.crypto._
 import eu.timepit.refined.types.numeric.PosInt
+
 object Fs2Pgp {
   implicit val lf: LoggerFactory[IO] = org.typelevel.log4cats.noop.NoOpFactory.impl[IO]
   val key =

--- a/scalafix/input/src/main/scala/fix/Fs2Pgp.scala
+++ b/scalafix/input/src/main/scala/fix/Fs2Pgp.scala
@@ -46,8 +46,7 @@ object Fs2Pgp {
       |-----END PGP PUBLIC KEY BLOCK-----""".stripMargin
   val wrappedKey = PGPKeyAlg[IO].readPublicKey(key).unsafeRunSync()
   val pos = PosInt(100)
-  val chunkSize = tagChunkSize(PosInt(100))
-  val chunkSize2 = tagChunkSize(pos)
+
   (for {
     crypto <- Stream.resource(CryptoAlg[IO])
     output <- Stream.emit("hello world")

--- a/scalafix/input/src/main/scala/fix/Fs2Pgp.scala
+++ b/scalafix/input/src/main/scala/fix/Fs2Pgp.scala
@@ -46,6 +46,7 @@ object Fs2Pgp {
       |-----END PGP PUBLIC KEY BLOCK-----""".stripMargin
   val wrappedKey = PGPKeyAlg[IO].readPublicKey(key).unsafeRunSync()
   val pos = PosInt(100)
+  val chunkSize = tagChunkSize(pos)
 
   (for {
     crypto <- Stream.resource(CryptoAlg[IO])

--- a/scalafix/output/src/main/scala/example/SeveralDifferentUses.scala
+++ b/scalafix/output/src/main/scala/example/SeveralDifferentUses.scala
@@ -1,0 +1,30 @@
+package example
+
+import cats.effect.*
+import com.dwolla.security.crypto.*
+import org.bouncycastle.openpgp.PGPPublicKey
+import org.typelevel.log4cats.LoggerFactory
+
+object SeveralDifferentUses {
+  private def key: PGPPublicKey = ???
+  private def chunkSize: ChunkSize = ???
+  private implicit def loggerFactory: LoggerFactory[IO] = ???
+
+  CryptoAlg.resource[IO].evalMap { alg =>
+
+    // all arguments set
+    alg.encrypt(EncryptionConfig().withChunkSize(chunkSize).withFileName(Option("filename")).withEncryption(Encryption.Aes256).withCompression(Compression.Bzip2).withPacketFormat(PgpLiteralDataPacketFormat.Utf8), key)
+
+    // all arguments set with named parameters
+    alg.encrypt(EncryptionConfig().withChunkSize(chunkSize).withFileName(Option("filename")).withEncryption(Encryption.Aes256).withCompression(Compression.Bzip2).withPacketFormat(PgpLiteralDataPacketFormat.Utf8), key)
+    alg.encrypt(EncryptionConfig().withChunkSize(chunkSize).withFileName(Option("filename")).withEncryption(Encryption.Aes256).withCompression(Compression.Bzip2).withPacketFormat(PgpLiteralDataPacketFormat.Utf8), key)
+
+    // random assortments
+    alg.encrypt(EncryptionConfig().withChunkSize(chunkSize).withFileName(Option("filename")), key)
+    alg.encrypt(EncryptionConfig().withFileName(Option("filename")).withChunkSize(chunkSize), key)
+    alg.encrypt(EncryptionConfig().withEncryption(Encryption.Aes256).withPacketFormat(PgpLiteralDataPacketFormat.Utf8), key)
+    alg.encrypt(EncryptionConfig().withFileName(Option("filename")).withCompression(Compression.Bzip2), key)
+
+    ???
+  }
+}

--- a/scalafix/output/src/main/scala/example/SeveralDifferentUses.scala
+++ b/scalafix/output/src/main/scala/example/SeveralDifferentUses.scala
@@ -2,6 +2,7 @@ package example
 
 import cats.effect.*
 import com.dwolla.security.crypto.*
+import eu.timepit.refined.auto.*
 import org.bouncycastle.openpgp.PGPPublicKey
 import org.typelevel.log4cats.LoggerFactory
 
@@ -14,13 +15,19 @@ object SeveralDifferentUses {
 
     // all arguments set
     alg.encrypt(EncryptionConfig().withChunkSize(chunkSize).withFileName(Option("filename")).withEncryption(Encryption.Aes256).withCompression(Compression.Bzip2).withPacketFormat(PgpLiteralDataPacketFormat.Utf8), key)
+    alg.encrypt(EncryptionConfig().withChunkSize(ChunkSize(42)).withFileName(Option("filename")).withEncryption(Encryption.Aes256).withCompression(Compression.Bzip2).withPacketFormat(PgpLiteralDataPacketFormat.Utf8), key)
 
     // all arguments set with named parameters
     alg.encrypt(EncryptionConfig().withChunkSize(chunkSize).withFileName(Option("filename")).withEncryption(Encryption.Aes256).withCompression(Compression.Bzip2).withPacketFormat(PgpLiteralDataPacketFormat.Utf8), key)
+    alg.encrypt(EncryptionConfig().withChunkSize({
+      ChunkSize(42)
+    }).withFileName(Option("filename")).withEncryption(Encryption.Aes256).withCompression(Compression.Bzip2).withPacketFormat(PgpLiteralDataPacketFormat.Utf8), key)
     alg.encrypt(EncryptionConfig().withChunkSize(chunkSize).withFileName(Option("filename")).withEncryption(Encryption.Aes256).withCompression(Compression.Bzip2).withPacketFormat(PgpLiteralDataPacketFormat.Utf8), key)
 
     // random assortments
-    alg.encrypt(EncryptionConfig().withChunkSize(chunkSize).withFileName(Option("filename")), key)
+    alg.encrypt(EncryptionConfig().withChunkSize({
+      ChunkSize(42)
+    }).withFileName(Option("filename")), key)
     alg.encrypt(EncryptionConfig().withFileName(Option("filename")).withChunkSize(chunkSize), key)
     alg.encrypt(EncryptionConfig().withEncryption(Encryption.Aes256).withPacketFormat(PgpLiteralDataPacketFormat.Utf8), key)
     alg.encrypt(EncryptionConfig().withFileName(Option("filename")).withCompression(Compression.Bzip2), key)

--- a/scalafix/output/src/main/scala/example/UsesCryptoAlg.scala
+++ b/scalafix/output/src/main/scala/example/UsesCryptoAlg.scala
@@ -1,0 +1,24 @@
+package example
+
+import cats.effect.*
+import com.dwolla.security.crypto.*
+import eu.timepit.refined.types.all.PosInt
+import fs2.*
+import org.bouncycastle.openpgp.PGPPublicKey
+import org.typelevel.log4cats.LoggerFactory
+
+object UsesCryptoAlg extends ResourceApp.Simple {
+  private def key: PGPPublicKey = ???
+  private def untaggedChunkSize: PosInt = ???
+  private implicit def loggerFactory: LoggerFactory[IO] = ???
+
+  override def run: Resource[IO, Unit] =
+    CryptoAlg.resource[IO].evalMap { alg =>
+      Stream
+        .empty
+        .through(alg.encrypt(EncryptionConfig().withChunkSize(ChunkSize(untaggedChunkSize)).withFileName(Option("filename")).withEncryption(Encryption.Aes256).withCompression(Compression.Bzip2).withPacketFormat(PgpLiteralDataPacketFormat.Utf8), key))
+        .through(alg.armor)
+        .compile
+        .drain
+    }
+}

--- a/scalafix/output/src/main/scala/fix/Fs2Pgp.scala
+++ b/scalafix/output/src/main/scala/fix/Fs2Pgp.scala
@@ -44,6 +44,7 @@ object Fs2Pgp {
       |-----END PGP PUBLIC KEY BLOCK-----""".stripMargin
   val wrappedKey = PGPKeyAlg[IO].readPublicKey(key).unsafeRunSync()
   val pos = PosInt(100)
+  val chunkSize = ChunkSize(pos)
 
   (for {
     crypto <- Stream.resource(CryptoAlg.resource[IO])

--- a/scalafix/output/src/main/scala/fix/Fs2Pgp.scala
+++ b/scalafix/output/src/main/scala/fix/Fs2Pgp.scala
@@ -8,6 +8,8 @@ import fs2._
 import fs2.text._
 import com.dwolla.security.crypto._
 import eu.timepit.refined.types.numeric.PosInt
+import com.dwolla.security.crypto.ChunkSize
+
 object Fs2Pgp {
   implicit val lf: LoggerFactory[IO] = org.typelevel.log4cats.noop.NoOpFactory.impl[IO]
   val key =
@@ -42,8 +44,8 @@ object Fs2Pgp {
       |=TJUS
       |-----END PGP PUBLIC KEY BLOCK-----""".stripMargin
   val wrappedKey = PGPKeyAlg[IO].readPublicKey(key).unsafeRunSync()
-  val pos = PosInt.unsafeFrom(100)
-  val chunkSize = ChunkSize(PosInt.unsafeFrom(100))
+  val pos = PosInt(100)
+  val chunkSize = ChunkSize(PosInt(100))
   val chunkSize2 = ChunkSize(pos)
   (for {
     crypto <- Stream.resource(CryptoAlg.resource[IO])

--- a/scalafix/output/src/main/scala/fix/Fs2Pgp.scala
+++ b/scalafix/output/src/main/scala/fix/Fs2Pgp.scala
@@ -8,7 +8,6 @@ import fs2._
 import fs2.text._
 import com.dwolla.security.crypto._
 import eu.timepit.refined.types.numeric.PosInt
-import com.dwolla.security.crypto.ChunkSize
 
 object Fs2Pgp {
   implicit val lf: LoggerFactory[IO] = org.typelevel.log4cats.noop.NoOpFactory.impl[IO]
@@ -45,8 +44,7 @@ object Fs2Pgp {
       |-----END PGP PUBLIC KEY BLOCK-----""".stripMargin
   val wrappedKey = PGPKeyAlg[IO].readPublicKey(key).unsafeRunSync()
   val pos = PosInt(100)
-  val chunkSize = ChunkSize(PosInt(100))
-  val chunkSize2 = ChunkSize(pos)
+
   (for {
     crypto <- Stream.resource(CryptoAlg.resource[IO])
     output <- Stream.emit("hello world")

--- a/scalafix/rules/src/main/scala/com/dwolla/security/crypto/V04to05.scala
+++ b/scalafix/rules/src/main/scala/com/dwolla/security/crypto/V04to05.scala
@@ -6,17 +6,14 @@ import scala.meta.*
 class V04to05 extends SemanticRule("com.dwolla.security.crypto.V04to05") {
 
   override def fix(implicit doc: SemanticDocument): Patch = {
+    Patch.replaceSymbols(
+      "com.dwolla.security.crypto.tagChunkSize" -> "com.dwolla.security.crypto.ChunkSize"
+    ) ++
     doc.tree.collect {
       case t@Term.ApplyType.After_4_6_0(Term.Name("CryptoAlg"), Type.ArgClause(List(Type.Name(name)))) =>
         Patch.replaceTree(t, s"CryptoAlg.resource[$name]").atomic
       case t@Term.Apply.After_4_6_0(Term.Select(Term.Name(name), Term.Name("armor")), Term.ArgClause(List(), None)) =>
         Patch.replaceTree(t, s"$name.armor").atomic
-      case t@Term.Apply.After_4_6_0(Term.Name("tagChunkSize"), _) =>
-        Patch.renameSymbol(t.symbol, "ChunkSize")
-      case t@Term.Apply.After_4_6_0(
-        Term.Name("PosInt"),
-        Term.ArgClause(List(Lit.Int(posIntArg)), None)
-      ) => Patch.replaceTree(t, s"PosInt.unsafeFrom($posIntArg)").atomic
       case t@
         Term.Apply.After_4_6_0(
           Term.Select(Term.Name(cryptoRName), Term.Name("encrypt")),
@@ -29,6 +26,6 @@ class V04to05 extends SemanticRule("com.dwolla.security.crypto.V04to05") {
           )
         ) =>
         Patch.replaceTree(t, s"$cryptoRName.encrypt(EncryptionConfig().withFileName($fileNameTerm), $keyName)")
-    }.asPatch
+    }
   }
 }

--- a/scalafix/rules/src/main/scala/com/dwolla/security/crypto/V04to05.scala
+++ b/scalafix/rules/src/main/scala/com/dwolla/security/crypto/V04to05.scala
@@ -1,31 +1,84 @@
 package com.dwolla.security.crypto
 
 import scalafix.v1.*
+
 import scala.meta.*
 
 class V04to05 extends SemanticRule("com.dwolla.security.crypto.V04to05") {
 
-  override def fix(implicit doc: SemanticDocument): Patch = {
-    Patch.replaceSymbols(
-      "com.dwolla.security.crypto.tagChunkSize" -> "com.dwolla.security.crypto.ChunkSize"
-    ) ++
+  override def fix(implicit doc: SemanticDocument): Patch =
     doc.tree.collect {
       case t@Term.ApplyType.After_4_6_0(Term.Name("CryptoAlg"), Type.ArgClause(List(Type.Name(name)))) =>
         Patch.replaceTree(t, s"CryptoAlg.resource[$name]").atomic
       case t@Term.Apply.After_4_6_0(Term.Select(Term.Name(name), Term.Name("armor")), Term.ArgClause(List(), None)) =>
         Patch.replaceTree(t, s"$name.armor").atomic
-      case t@
-        Term.Apply.After_4_6_0(
-          Term.Select(Term.Name(cryptoRName), Term.Name("encrypt")),
-          Term.ArgClause(
-            List(
-              Term.Name(keyName),
-              Term.Assign( Term.Name("fileName"), fileNameTerm )
-            ),
-            None
-          )
-        ) =>
-        Patch.replaceTree(t, s"$cryptoRName.encrypt(EncryptionConfig().withFileName($fileNameTerm), $keyName)")
+      case Term.Apply.After_4_6_0(Term.Select(Term.Name(_), fun@Term.Name("encrypt")), t@Term.ArgClause((keyName@Term.Name(_)) :: additionalArguments, None)) =>
+        migrateEncrypt(t, fun, additionalArguments, Some(keyName), offset = 1)
+      case Term.Apply.After_4_6_0(Term.Select(Term.Name(_), fun@Term.Name("encrypt")), t@Term.ArgClause(arguments, None)) =>
+        migrateEncrypt(t, fun, arguments, None, offset = 0)
+//      case t@Term.Apply.After_4_6_0(Term.Name("tagChunkSize"), _) =>
+//        Patch.replaceToken(t.tokens.head, "ChunkSizeFromFix")
+    }.asPatch
+
+  private def migrateEncrypt(t: Term.ArgClause,
+                             fun: Term.Name,
+                             arguments: List[Term],
+                             keyName: Option[Term],
+                             offset: Int,
+                            )
+                            (implicit doc: SemanticDocument): Patch = {
+    val map = arguments.zipWithIndex.foldLeft(keyName.map("key" -> _).toList) {
+      case (s, (Term.Assign(Term.Name("key"), term), _)) => s :+ ("key" -> term)
+      case (s, (Term.Assign(Term.Name("chunkSize"), Term.Apply.After_4_6_0(Term.Name("tagChunkSize"), Term.ArgClause(List(term), _))), _)) =>
+        s :+ ("ChunkSize" -> term)
+      case (s, (Term.Assign(Term.Name(name), term), _)) => s :+ (name.capitalize -> term)
+      case (s, (value, i)) =>
+        fun.symbol.info match {
+          case Some(info) =>
+            info.signature match {
+              case method: MethodSignature if method.parameterLists.nonEmpty =>
+                val parameter = method.parameterLists.head(i + offset)
+                val parameterName = parameter.displayName
+
+                s :+ (parameterName.capitalize -> value)
+            }
+          case _ => s
+        }
+      case (s, _) => s
     }
+
+// TODO maybe try replacing the specific arguments instead of the entire tree?
+//    import scala.meta.tokens.Token.{Comma, Space}
+//    Patch.addLeft(arguments.head, "EncryptionConfig()") +
+//      sortKeyToEnd(map)
+//        .map {
+//          case ("key", t) => Patch.removeTokens(t.tokens)
+//          case (s, arg) =>
+//            t.tokens.foreach(t => println(s"${t.getClass} -> $t"))
+//            Patch.addAround(arg, s".with$s(", ")")
+//        }
+//        .asPatch +
+//      Patch.removeTokens(t.tokens.filter(_.is[Comma])) +
+//      Patch.addRight(arguments.last, s", ${map.toMap.apply("key")}")
+
+    Patch.replaceTree(t, sortKeyToEnd(map).foldLeft(s"(EncryptionConfig()") {
+      case (s, ("key", term)) => s + s", $term)"
+      case (s, (argName, Term.Apply.After_4_6_0(Term.Name("tagChunkSize"), Term.ArgClause(List(term), _)))) => s + s".with$argName(ChunkSize($term))"
+      case (s, (argName, term)) => s + s".with$argName($term)"
+    })
   }
+
+  private def sortKeyToEnd(terms: List[(String, Term)]): List[(String, Term)] = {
+    val key = terms.toMap.apply("key")
+
+    val remainder = terms
+      .filterNot {
+        case ("key", _) => true
+        case _ => false
+      }
+
+    remainder :+ ("key" -> key)
+  }
+
+
 }


### PR DESCRIPTION
I think this covers the migration cases I was looking for, with the exception that I haven't been able to figure out how to globally replace `tagChunkSize` with `ChunkSize` and also have it work inline in a `encrypt` method call without publishing two separate rules. 

Unless anyone has any great ideas, on Monday I'll probably start working on a second rule and documentation stating "run the `tagChunkSize` → `ChunkSize` rule first" and then the more universal rule second.