### PR TITLE
[scalafix] tagChunkSize migration fix

### DIFF
--- a/scalafix/input/src/main/scala/fix/Fs2Pgp.scala
+++ b/scalafix/input/src/main/scala/fix/Fs2Pgp.scala
@@ -46,6 +46,7 @@ object Fs2Pgp {
       |-----END PGP PUBLIC KEY BLOCK-----""".stripMargin
   val wrappedKey = PGPKeyAlg[IO].readPublicKey(key).unsafeRunSync()
   val pos = PosInt(100)
+  val chunkSize = tagChunkSize(pos)
 
   (for {
     crypto <- Stream.resource(CryptoAlg[IO])

--- a/scalafix/output/src/main/scala/fix/Fs2Pgp.scala
+++ b/scalafix/output/src/main/scala/fix/Fs2Pgp.scala
@@ -44,6 +44,7 @@ object Fs2Pgp {
       |-----END PGP PUBLIC KEY BLOCK-----""".stripMargin
   val wrappedKey = PGPKeyAlg[IO].readPublicKey(key).unsafeRunSync()
   val pos = PosInt(100)
+  val chunkSize = ChunkSize(pos)
 
   (for {
     crypto <- Stream.resource(CryptoAlg.resource[IO])


### PR DESCRIPTION
@bpholt I think this should do the trick, coupled with your fix for when `tagChunkSize` shows up in `alg.encrypt`